### PR TITLE
refactor(6 pages): Review code in design patterns

### DIFF
--- a/mise-en-page/accueil-institution-directives.html
+++ b/mise-en-page/accueil-institution-directives.html
@@ -1,513 +1,523 @@
-
-<!DOCTYPE html><!--[if lt IE 9]><html class="no-js lt-ie9" lang="en" dir="ltr"><![endif]--><!--[if gt IE 8]><!-->
+<!DOCTYPE html>
+<!--[if lt IE 9]><html class="no-js lt-ie9" lang="en" dir="ltr"><![endif]-->
+<!--[if gt IE 8]><!-->
 <html class="no-js" lang="fr" dir="ltr">
 <!--<![endif]-->
+
 <head>
-<meta charset="utf-8">
-<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+	<meta charset="utf-8">
+	<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
 		wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
-		<title>Gabarit de page d'accueil institutionnelle avec directives - Modèle obligatoire de Canada.ca - Canada.ca</title>
+	<title>Gabarit de page d'accueil institutionnelle avec directives - Modèle obligatoire de Canada.ca - Canada.ca</title>
 
-		<meta content="width=device-width,initial-scale=1" name="viewport">
+	<meta content="width=device-width,initial-scale=1" name="viewport">
 
-		<!--[if gte IE 9 | !IE ]><!-->
-		<link href="https://www.canada.ca/etc/designs/canada/wet-boew/assets/favicon.ico" rel="icon" type="image/x-icon">
-		<link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/css/theme.min.css">
-		<link rel="stylesheet" href="../css/custom.css">
-		<link rel="stylesheet" href="../css/ip.css">
-		<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css">
-<!--<![endif]-->
-<!--[if lt IE 9]>
+	<!--[if gte IE 9 | !IE ]><!-->
+	<link href="https://www.canada.ca/etc/designs/canada/wet-boew/assets/favicon.ico" rel="icon" type="image/x-icon">
+	<link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/css/theme.min.css">
+	<link rel="stylesheet" href="../css/custom.css">
+	<link rel="stylesheet" href="../css/ip.css">
+	<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css">
+	<!--<![endif]-->
+	<!--[if lt IE 9]>
 		<link href="./GCWeb/assets/favicon.ico" rel="shortcut icon" />
 
 		<link rel="stylesheet" href="http://wet-boew.github.io/themes-dist/GCWeb/GCWeb/css/ie8-theme.min.css" />
 		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
 		<script src="./wet-boew/js/ie8-wet-boew.min.js"></script>
 		<![endif]-->
-<!--[if lte IE 9]>
+	<!--[if lte IE 9]>
 
 
 		<![endif]-->
-<noscript><link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/wet-boew/css/noscript.min.css" /></noscript>
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	<noscript>
+		<link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/wet-boew/css/noscript.min.css" /></noscript>
+	<script>
+		(function (i, s, o, g, r, a, m) {
+		i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
+			(i[r].q = i[r].q || []).push(arguments)
+		}, i[r].l = 1 * new Date(); a = s.createElement(o),
+			m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
+		})(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
 
-  ga('create', 'UA-105628416-1', 'auto');
-  ga('send', 'pageview');
+		ga('create', 'UA-105628416-1', 'auto');
+		ga('send', 'pageview');
 
-</script>
+	</script>
 
-<!-- Global site tag (gtag.js) - Google Analytics -->
+	<!-- Global site tag (gtag.js) - Google Analytics -->
 
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-105628416-3"></script>
+	<script async src="https://www.googletagmanager.com/gtag/js?id=UA-105628416-3"></script>
 
-<script>
+	<script>
 
-  window.dataLayer = window.dataLayer || [];
+		window.dataLayer = window.dataLayer || [];
 
-  function gtag(){dataLayer.push(arguments);}
+		function gtag() { dataLayer.push(arguments); }
 
-  gtag('js', new Date());
+		gtag('js', new Date());
 
 
 
-  gtag('config', 'UA-105628416-3');
+		gtag('config', 'UA-105628416-3');
 
-</script>
+	</script>
 </head>
+
 <body class="cnt-wdth-lmtd" vocab="http://schema.org/" typeof="WebPage">
-<ul id="wb-tphp">
-<li class="wb-slc">
-	<a class="wb-sl" href="#wb-cont">Passer au contenu principal</a>
-</li>
-<li class="wb-slc">
-	<a class="wb-sl" href="#wb-info">Passer à «&#160;Au sujet du gouvernement&#160;»</a>
-</li>
-</ul>
-<header>
-<div id="wb-bnr" class="container">
-<section id="wb-lng" class="text-right">
-<h2 class="wb-inv">Sélection de la langue</h2>
-<div class="row">
-<div class="col-md-12">
-<ul class="list-inline margin-bottom-none">
-	<li><a lang="en" href="https://design.canada.ca/coded-layout/institutional_landing_page_guidance.html">English</a></li>
-</ul>
-</div>
-</div>
-</section>
-<div class="row">
-<div class="brand col-xs-5 col-md-4">
-<a href="https://www.canada.ca/fr.html"><img src="http://www.canada.ca/etc/designs/canada/wet-boew/assets/sig-blk-fr.svg" alt=""><span class="wb-inv"> Gouvernement du Canada / <span lang="en">Government of Canada</span></span></a>
-</div>
-<section id="wb-srch" class="col-lg-8 text-right">
-	<h2>Recherche</h2>
-<form action="https://recherche-search.gc.ca/rGs/s_r?#wb-land" method="get" role="search" class="form-inline">
+	<ul id="wb-tphp">
+		<li class="wb-slc">
+			<a class="wb-sl" href="#wb-cont">Passer au contenu principal</a>
+		</li>
+		<li class="wb-slc">
+			<a class="wb-sl" href="#wb-info">Passer à «&#160;Au sujet du gouvernement&#160;»</a>
+		</li>
+	</ul>
+	<header>
+		<div id="wb-bnr" class="container">
+			<section id="wb-lng" class="text-right">
+				<h2 class="wb-inv">Sélection de la langue</h2>
+				<div class="row">
+					<div class="col-md-12">
+						<ul class="list-inline margin-bottom-none">
+							<li><a lang="en" href="https://design.canada.ca/coded-layout/institutional_landing_page_guidance.html">English</a></li>
+						</ul>
+					</div>
+				</div>
+			</section>
+			<div class="row">
+				<div class="brand col-xs-5 col-md-4">
+					<a href="https://www.canada.ca/fr.html"><img src="http://www.canada.ca/etc/designs/canada/wet-boew/assets/sig-blk-fr.svg" alt=""><span class="wb-inv"> Gouvernement du Canada / <span lang="en">Government of Canada</span></span></a>
+				</div>
+				<section id="wb-srch" class="col-lg-8 text-right">
+					<h2>Recherche</h2>
+					<form action="https://recherche-search.gc.ca/rGs/s_r?#wb-land" method="get" role="search" class="form-inline">
 
-<div class="form-group">
+						<div class="form-group">
 
-	<label for="wb-srch-q" class="wb-inv">Rechercher dans Canada.ca</label>
+							<label for="wb-srch-q" class="wb-inv">Rechercher dans Canada.ca</label>
 
-	<input id="wb-srch-q" list="wb-srch-q-ac" class="wb-srch-q form-control" name="q" type="search" value="" size="34" maxlength="170" placeholder="Rechercher dans Canada.ca">
+							<input id="wb-srch-q" list="wb-srch-q-ac" class="wb-srch-q form-control" name="q" type="search" value="" size="34" maxlength="170" placeholder="Rechercher dans Canada.ca">
 
-<input name="st" value="s" type="hidden"/>
+							<input name="st" value="s" type="hidden" />
 
-<input name="num" value="10" type="hidden"/>
+							<input name="num" value="10" type="hidden" />
 
-<input name="langs" value="fra" type="hidden"/>
+							<input name="langs" value="fra" type="hidden" />
 
-<input name="st1rt" value="0" type="hidden">
+							<input name="st1rt" value="0" type="hidden">
 
-<input name="s5bm3ts21rch" value="x" type="hidden"/>
+							<input name="s5bm3ts21rch" value="x" type="hidden" />
 
-<datalist id="wb-srch-q-ac">
+							<datalist id="wb-srch-q-ac">
 
-<!--[if lte IE 9]><select><![endif]-->
+								<!--[if lte IE 9]><select><![endif]-->
 
-<!--[if lte IE 9]></select><![endif]-->
+								<!--[if lte IE 9]></select><![endif]-->
 
-</datalist>
+							</datalist>
 
-</div>
+						</div>
 
-<div class="form-group submit">
+						<div class="form-group submit">
 
-	<button type="submit" id="wb-srch-sub" class="btn btn-primary btn-small" name="wb-srch-sub"><span class="glyphicon-search glyphicon"></span><span class="wb-inv">Recherche</span></button>
-
-
-</div>
-
-</form>
+							<button type="submit" id="wb-srch-sub" class="btn btn-primary btn-small" name="wb-srch-sub"><span class="glyphicon-search glyphicon"></span><span class="wb-inv">Recherche</span></button>
 
 
-</section>
-</div>
-</div>
-<nav class="gweb-v2 gcweb-menu" typeof="SiteNavigationElement">
-<div class="container">
-<h2 class="wb-inv">Menu</h2>
-<button type="button" aria-haspopup="true" aria-controls="gc-mnu" aria-expanded="false">Menu<span class="wb-inv"> principal</span> <span class="expicon glyphicon glyphicon-chevron-down"></span></button>
-<ul id="gc-mnu" role="menu" aria-orientation="vertical" data-ajax-replace="https://www.canada.ca/content/dam/canada/sitemenu/sitemenu-v2-fr.html">
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/jobs.html">Emplois et milieu de travail</a></li>
+						</div>
 
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/immigration-citizenship.html">Immigration et citoyenneté</a></li>
+					</form>
 
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://voyage.gc.ca/">Voyage et tourisme</a></li>
 
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/entreprises.html">Entreprises et industrie</a></li>
+				</section>
+			</div>
+		</div>
+		<nav class="gweb-v2 gcweb-menu" typeof="SiteNavigationElement">
+			<div class="container">
+				<h2 class="wb-inv">Menu</h2>
+				<button type="button" aria-haspopup="true" aria-controls="gc-mnu" aria-expanded="false">Menu<span class="wb-inv"> principal</span> <span class="expicon glyphicon glyphicon-chevron-down"></span></button>
+				<ul id="gc-mnu" role="menu" aria-orientation="vertical" data-ajax-replace="https://www.canada.ca/content/dam/canada/sitemenu/sitemenu-v2-fr.html">
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/jobs.html">Emplois et milieu de travail</a></li>
 
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/benefits.html">Prestations</a></li>
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/immigration-citizenship.html">Immigration et citoyenneté</a></li>
 
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/sante.html">Santé</a></li>
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://voyage.gc.ca/">Voyage et tourisme</a></li>
 
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/impots.html">Impôts</a></li>
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/entreprises.html">Entreprises et industrie</a></li>
 
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/environnement.html">Environnement et ressources naturelles</a></li>
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/benefits.html">Prestations</a></li>
 
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/defense.html">Sécurité nationale et défense</a></li>
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/sante.html">Santé</a></li>
 
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/culture.html">Culture, histoire et sport</a></li>
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/impots.html">Impôts</a></li>
 
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/police.html">Services de police, justice et urgences</a></li>
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/environnement.html">Environnement et ressources naturelles</a></li>
 
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/transport.html">Transport et infrastructure</a></li>
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/defense.html">Sécurité nationale et défense</a></li>
 
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="http://international.gc.ca/world-monde/index.aspx?lang=fra">Canada et le monde</a></li>
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/culture.html">Culture, histoire et sport</a></li>
 
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/finance.html">Argent et finances</a></li>
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/police.html">Services de police, justice et urgences</a></li>
 
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/science.html">Science et innovation</a></li>
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/transport.html">Transport et infrastructure</a></li>
 
-</ul>
-</div>
-</nav>
-<nav id="wb-bc" property="breadcrumb">
-<h2>Vous êtes ici :</h2>
-<div class="container">
-<ol class="breadcrumb">
-	<li><a href='https://www.canada.ca/fr.html'>Accueil</a></li>
-	<li><a href='https://www.canada.ca/fr/gouvernement/a-propos.html'>À propos de Canada.ca</a></li>
-<li><a href='https://www.canada.ca/fr/gouvernement/a-propos/systeme-conception.html'>Système de conception de Canada.ca</a></li>
-	<li><a href='https://www.canada.ca/fr/gouvernement/a-propos/systeme-conception/bibliotheque-modeles.html'>Bibliothèque de modèles et de configurations de conception</a></li>
-	<li><a href='https://www.canada.ca/fr/gouvernement/a-propos/systeme-conception/bibliotheque-modeles.html'>Page d'accueil institutionnelle</a></li>
-</ol>
-</div>
-</nav>
-</header>
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="http://international.gc.ca/world-monde/index.aspx?lang=fra">Canada et le monde</a></li>
 
-<style> /* to move later */
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/finance.html">Argent et finances</a></li>
 
-/* added to detail summaries inside the code to remove the bottom spacing */
-.pattern-demo-code-ex details {
-	margin-bottom: 0px !important;
-}
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/science.html">Science et innovation</a></li>
 
-.pattern-demo-code-ex .featured {
-	margin-left: .07em !important;
-	margin-right: .07em !important;
-}
+				</ul>
+			</div>
+		</nav>
+		<nav id="wb-bc" property="breadcrumb">
+			<h2>Vous êtes ici :</h2>
+			<div class="container">
+				<ol class="breadcrumb">
+					<li><a href='https://www.canada.ca/fr.html'>Accueil</a></li>
+					<li><a href='https://www.canada.ca/fr/gouvernement/a-propos.html'>À propos de Canada.ca</a></li>
+					<li><a href='https://www.canada.ca/fr/gouvernement/a-propos/systeme-conception.html'>Système de conception de Canada.ca</a></li>
+					<li><a href='https://www.canada.ca/fr/gouvernement/a-propos/systeme-conception/bibliotheque-modeles.html'>Bibliothèque de modèles et de configurations de conception</a></li>
+					<li><a href='https://www.canada.ca/fr/gouvernement/a-propos/systeme-conception/bibliotheque-modeles.html'>Page d'accueil institutionnelle</a></li>
+				</ol>
+			</div>
+		</nav>
+	</header>
 
-/* .pattern-demo-code-ex .gc-prtts {
+	<style>
+		/* to move later */
+
+		/* added to detail summaries inside the code to remove the bottom spacing */
+		.pattern-demo-code-ex details {
+			margin-bottom: 0px !important;
+		}
+
+		.pattern-demo-code-ex .featured {
+			margin-left: .07em !important;
+			margin-right: .07em !important;
+		}
+
+		/* .pattern-demo-code-ex .gc-prtts {
 	width: 99%;
 } */
 
-.pattern-demo {
-	padding: 0px !important;
-	margin: 0px !important;
-	border: none !important;
-}
+		.pattern-demo {
+			padding: 0px !important;
+			margin: 0px !important;
+			border: none !important;
+		}
 
-.pattern-demo-code-ex {
-	margin-left: -35px !important;
-	margin-right: -35px !important;
-}
+		.pattern-demo-code-ex {
+			margin-left: -35px !important;
+			margin-right: -35px !important;
+		}
 
-.guidance-details details, .guidance-details summary, .guidance-details details summary:focus, .guidance-details details summary:hover {
-	background-color: white;
-}
+		.guidance-details details,
+		.guidance-details summary,
+		.guidance-details details summary:focus,
+		.guidance-details details summary:hover {
+			background-color: white;
+		}
+	</style>
 
-</style>
-
-</div>
-
-
-
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<!--/* Hide Nav; Hide Right Rail /*-->
-
-<main property="mainContentOfPage" typeof="WebPageElement">
-	<div class="container">
-		<p><a class="btn btn-primary" href="./accueil-institution-ng.html">Enlever les directives</a> <a class="btn btn-default" href="../modeles-obligatoire/pages-profil-institutionnel-2.html">Retourner à la page du modèle</a></p>
 	</div>
-  <div class="ip-cover-img">
-    <div class="container">
-      <div class="col-lg-7 col-md-7 row">
-        <h1 property="name" id="wb-cont">[Nom de l'institution]</h1>
-        <div class="clearfix"></div>
-        <p>Brève description du mandat de l'institution.</p>
-        <div class="col-lg-12 col-md-12 row">
-          <a class="btn btn-call-to-action ip-btn" href="#">Bouton vers une super-tâche [facultatif]</a>
-        </div>
-      </div>
-			<div class="row guidance-details">
-				<div class="col-md-8">
-					<details>
-						<summary><b>Directives : </b> fil d'Ariane, titre, image et bouton vers une super-tâche <i class="fas fa-info-circle"></i></summary>
-						<section>
-							<h3>Fil d'Ariane</h3>
-							<p><span class="label label-danger">Obligatoire</span></p>
-							<p>Le fil d'Ariane est : <a href="https://www.canada.ca/fr.html">Accueil</a> > <a href="https://www.canada.ca/fr/gouvernement/min.html">Ministères et organismes</a>.</p>
 
-						</section>
-						<section>
-							<h3>Titre</h3>
-							<p><span class="label label-danger">Obligatoire</span></p>
-							<p>Utilisez le titre d’usage de l’institution indiqué dans le <a href="https://www.tbs-sct.gc.ca/hgw-cgf/oversight-surveillance/communications/fip-pcim/reg-fra.asp">Registre des titres d’usage</a>.</p>
-							<p>Utilisez le titre légal si le titre d’usage n’est pas disponible.</p>
-							<p>N'utilisez pas d’acronymes ou d’abréviations.</p>
-						</section>
 
-						<section>
-							<h3>Image</h3>
-							<p><span class="label label-info">Facultatif</span></p>
-							<p>La zone de 1200x726 derrière le H1 peut être utilisée pour une bannière ou une image. L'image n'a pas besoin d'occuper tout l'espace et peut être personnalisée au besoin.</p>
-							<p>L'image et le H1 doivent être visuellement distincts de la <a href="https://www.canada.ca/">page d'accueil de Canada.ca</a> afin d'éviter toute confusion entre la page d'accueil de l'institution et celle de Canada.ca.</p>
-							<p>Si vous n'utilisez pas d'image, l'arrière-plan devrait être blanc.</p>
-							<p><b>Variation:</b> Appliquez la classe <code>ip-cover-hide-mobile</code> en plus de <code>ip-cover-img</code> pour cacher l'image pour les appareils mobiles.</p>
-						</section>
 
-						<section>
-							<h3>Bouton vers une super-tâche</h3>
-							<p><span class="label label-info">Facultatif</span></p>
-							<p>N'incluez un bouton vers une super-tâche que s'il y a une tâche spécifique qui génère au moins un tiers des clics sur la page d'accueil de l'institution. Ceci est principalement destiné à faciliter la connexion à un compte.</p>
-						</section>
+	</div>
 
-					</details>
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<!--/* Hide Nav; Hide Right Rail /*-->
+
+	<main property="mainContentOfPage" typeof="WebPageElement">
+		<div class="container">
+			<p><a class="btn btn-primary" href="./accueil-institution-ng.html">Enlever les directives</a> <a class="btn btn-default" href="../modeles-obligatoire/pages-profil-institutionnel-2.html">Retourner à la page du modèle</a></p>
+		</div>
+		<div class="ip-cover-img">
+			<div class="container">
+				<div class="col-lg-7 col-md-7 row">
+					<h1 property="name" id="wb-cont">[Nom de l'institution]</h1>
+					<div class="clearfix"></div>
+					<p>Brève description du mandat de l'institution.</p>
+					<div class="col-lg-12 col-md-12 row">
+						<a class="btn btn-call-to-action ip-btn" href="#">Bouton vers une super-tâche [facultatif]</a>
+					</div>
 				</div>
-			</div>
-    </div>
-  </div>
-
-
-  <section class="featured row opct-90">
-    <h2 class="wb-inv">En vedette</h2>
-    <div class="container">
-      <span class="h5"><a href="#">Lien en vedette [facultatif]</a></span>
-			<div class="row guidance-details">
-				<div class="col-md-8">
-					<details>
-						<summary><b>Directives : </b> lien en vedette <i class="fas fa-info-circle"></i></summary>
-						<p><span class="label label-info">Facultatif</span></p>
-						<p>Le lien en vedette est un lien court et descriptif que votre institution doit mettre en évidence. Il devrait être utilisé pour attirer l'attention sur des avertissements ou des avis.</p>
-						<p>N'incluez pas d'image dans cette section.</p>
-						<p>L'en-tête «&nbsp;En vedette» dans cette section doit avoir la classe <code>wb-inv</code> afin qu'il ne soit pas visible, mais qu'il soit tout de même présent pour des raisons sémantiques et pour les lecteurs d'écran.</p>
-					</details>
-				</div>
-			</div>
-    </div>
-  </section>
-
-  <section class="most-requested well well-sm brdr-0">
-    <div class="container">
-      <h2 class="mrgn-tp-md">En demande</h2>
-      <ul class="wb-eqht list-unstyled mrgn-tp-md mrgn-bttm-sm lst-spcd-2 list-responsive-3"> <!-- can use 'list-responsive' to get 4 column option -->
-        <li><a href="#">[Lien vers une tâche principale]</a></li>
-        <li><a href="#">[Lien vers une tâche principale]</a></li>
-        <li><a href="#">[Lien vers une tâche principale]</a></li>
-        <li><a href="#">[Lien vers une tâche principale]</a></li>
-        <li><a href="#">[Lien vers une tâche principale]</a></li>
-        <li><a href="#">[Lien vers une tâche principale]</a></li>
-      </ul>
-			<div class="row guidance-details">
-				<div class="col-md-8">
-					<details>
-						<summary><b>Directives : </b> En demande <i class="fas fa-info-circle"></i></summary>
-						<p><span class="label label-info">Facultatif</span></p>
-						<p>Présente les tâches principales spécifiques à l'institution.</p>
-							<p>Cette composante fournit des raccourcis vers les tâches les plus importantes de l'institution. Cependant, si toutes les tâches principales de l'institution sont déjà incluses en tant que liens directs sous «&nbsp;Services et renseignements&nbsp;», ne les répétez pas ici. Dans ce cas, vous pouvez choisir de ne pas inclure cette composante.</p>
-						<p><strong>Variations:</strong> remplacez la classe <code>list-responsive-3</code> pour <code>list-responsive</code> pour présenter cette section en 4 colonnes au lieu de 3.</p>
-					</details>
-				</div>
-			</div>
-    </div>
-  </section>
-
-  <div class="container">
-
-    <section class="gc-srvinfo col-md-12 mrgn-bttm-lg row">
-      <h2 class="wb-inv">Services et renseignements</h2>
-      <div class="row">
-        <div class="wb-eqht">
-          <section class="col-md-4">
-            <h3><a href="#">[Texte de l'hyperlien]</a></h3>
-            <p>Utilisez des verbes d'action ou énumérez simplement des mots-clés pour résumer les renseignements ou les tâches qui peuvent être accomplis sur la page à laquelle il renvoie.</p>
-          </section>
-					<section class="col-md-4">
-            <h3><a href="#">[Texte de l'hyperlien]</a></h3>
-            <p>Utilisez des verbes d'action ou énumérez simplement des mots-clés pour résumer les renseignements ou les tâches qui peuvent être accomplis sur la page à laquelle il renvoie.</p>
-          </section>
-					<section class="col-md-4">
-            <h3><a href="#">[Texte de l'hyperlien]</a></h3>
-            <p>Utilisez des verbes d'action ou énumérez simplement des mots-clés pour résumer les renseignements ou les tâches qui peuvent être accomplis sur la page à laquelle il renvoie.</p>
-          </section>
-
-					<section class="col-md-4">
-            <h3><a href="#">[Texte de l'hyperlien]</a></h3>
-            <p>Utilisez des verbes d'action ou énumérez simplement des mots-clés pour résumer les renseignements ou les tâches qui peuvent être accomplis sur la page à laquelle il renvoie.</p>
-          </section>
-					<section class="col-md-4">
-            <h3><a href="#">[Texte de l'hyperlien]</a></h3>
-            <p>Utilisez des verbes d'action ou énumérez simplement des mots-clés pour résumer les renseignements ou les tâches qui peuvent être accomplis sur la page à laquelle il renvoie.</p>
-          </section>
-					<section class="col-md-4">
-            <h3><a href="#">[Texte de l'hyperlien]</a></h3>
-            <p>Utilisez des verbes d'action ou énumérez simplement des mots-clés pour résumer les renseignements ou les tâches qui peuvent être accomplis sur la page à laquelle il renvoie.</p>
-          </section>
-
-					<section class="col-md-4">
-            <h3><a href="#">[Texte de l'hyperlien]</a></h3>
-            <p>Utilisez des verbes d'action ou énumérez simplement des mots-clés pour résumer les renseignements ou les tâches qui peuvent être accomplis sur la page à laquelle il renvoie.</p>
-          </section>
-					<section class="col-md-4">
-            <h3><a href="#">[Texte de l'hyperlien]</a></h3>
-            <p>Utilisez des verbes d'action ou énumérez simplement des mots-clés pour résumer les renseignements ou les tâches qui peuvent être accomplis sur la page à laquelle il renvoie.</p>
-          </section>
-					<section class="col-md-4">
-            <h3><a href="#">[Texte de l'hyperlien]</a></h3>
-            <p>Utilisez des verbes d'action ou énumérez simplement des mots-clés pour résumer les renseignements ou les tâches qui peuvent être accomplis sur la page à laquelle il renvoie.</p>
-          </section>
-          <div class="clearfix"></div>
-        </div>
-      </div>
-			<div class="row guidance-details">
-				<div class="col-md-8">
-					<details>
-						<summary><b>Directives : </b> Services et renseignements <i class="fas fa-info-circle"></i></summary>
-						<p><span class="label label-danger">Obligatoire</span></p>
-						<p>Dresse la liste des sujets ou des tâches principales spécifiques à l’institution.</p>
-						<p>L'en-tête «&nbsp;services et renseignements&nbsp;» dans cette section doit avoir la classe <code>wb-inv</code> afin qu'il ne soit pas visible, mais qu'il soit tout de même présent pour des raisons sémantiques et pour les lecteurs d'écran.</p>
-						<p><b>Variations:</b> Toutes les variations du modèle <a href="../configurations-conception-communes/services-renseignements.html">Services et renseignements</a> peuvent être utilisées dans cette section.</li>
-					</details>
-				</div>
-			</div>
-    </section>
-
-  </div>
-
-  <section class="most-requested well well-sm brdr-0">
-    <div class="container">
-      <div class="wb-eqht row">
-        <h2 class="col-lg-3 h3">Coordonnées</h2>
-        <span class="clearfix"></span>
-        <section class="col-lg-4 col-md-6 col-sm-6">
-          <h3 class="h5"><a href="#">Communiquer avec [institution]</a></h3>
-        </section>
-        <section class="col-lg-4 col-md-6 col-sm-6">
-          <h3 class="h5"><a href="#">[Tâche de contact 2]</a></h3>
-        </section>
-        <section class="col-lg-4 col-md-6 col-sm-6">
-          <h3 class="h5"><a href="#">[Tâche de contact 3]</a></h3>
-        </section>
-      </div>
-      <div class="row">
-
-        <section class="col-md-8 pull-left mrgn-bttm-lg">
-          <h2 class="h3">À propos de [Institution]</h2>
-          <div class="wb-eqht row">
-            <div class="col-md-6">
-              <section>
-                <h3 class="h5">
-                  <a href="#">Mandat</a>
-                </h3>
-              </section>
-            </div>
-            <div class="col-md-6">
-              <section>
-                <h3 class="h5">
-                  <a href="#">Structure organisationnelle</a>
-                </h3>
-              </section>
-            </div>
-            <div class="col-md-6">
-              <section>
-                <h3 class="h5">
-                  <a href="#" rel="external">Transparence</a>
-                </h3>
-              </section>
-            </div>
-            <div class="col-md-6">
-              <section>
-                <h3 class="h5">
-                  <a href="#" rel="external">Possibilités d'emploi</a>
-                </h3>
-              </section>
-            </div>
-            <div class="col-md-6">
-              <section>
-                <h3 class="h5">
-                  <a href="#">Rapports</a>
-                </h3>
-              </section>
-            </div>
-            <div class="col-md-6">
-              <section>
-                <h3 class="h5">
-                  <a href="#">Observation</a>
-                </h3>
-              </section>
-            </div>
-            <div class="col-md-6">
-              <section>
-                <h3 class="h5">
-                  <a href="#">Avis de mesure d'exécution</a>
-                </h3>
-              </section>
-            </div>
-            <div class="col-md-6">
-              <section>
-                <h3 class="h5">
-                  <a href="#">Lien institutionnel</a>
-                </h3>
-              </section>
-            </div>
-            <div class="col-md-6">
-              <section>
-                <h3 class="h5">
-              <a href="#">Lien institutionnel</a>
-                </h3>
-              </section>
-            </div>
-            <div class="col-md-6">
-              <section>
-                <h3 class="h5">En savoir plus:
-                  <a href="#" rel="external">Au sujet de [institution]</a>
-                </h3>
-              </section>
-            </div>
-          </div>
-        </section>
-
-        <div class="col-md-4 col-sm-5 pull-right mobile-left">
-          <div class="visible-sm"></div>
-          <section class="lnkbx">
-            <h2 class="h3">Ministre</h2>
-            <p><a href="#">[(L'honorable) prénom et nom de famille]</a><br>
-              <small>Titre officiel du ministre</small></p>
-							<p><a href="#">[(L'honorable) prénom et nom de famille]</a><br>
-              <small>Titre officiel du ministre</small></p>
-							<p><a href="#">[(L'honorable) prénom et nom de famille]</a><br>
-                <small>Titre officiel du ministre</small></p>
-
-            <section class="row followus">
-              <h2 class="mrgn-tp-lg h3">Suivez</h2>
-              <br>
-              <ul>
-                <li><a href="https://www.facebook.com/canrevagency" class="facebook" rel="external"><span class="wb-inv">Facebook</span></a></li>
-                <li><a href="https://twitter.com/CanRevAgency" class="twitter" rel="external"><span class="wb-inv">Twitter</span></a></li>
-                <li><a href="https://www.youtube.com/user/CanRevAgency" class="youtube" rel="external"><span class="wb-inv">YouTube</span></a></li>
-                <li><a href="https://www.linkedin.com/company/cra-arc" class="linkedin" rel="external"><span class="wb-inv">LinkedIn</span></a></li>
-              </ul>
-            </section>
-          </section>
-        </div>
 				<div class="row guidance-details">
+					<div class="col-md-8">
+						<details>
+							<summary><b>Directives : </b> fil d'Ariane, titre, image et bouton vers une super-tâche <i class="fas fa-info-circle"></i></summary>
+							<section>
+								<h3>Fil d'Ariane</h3>
+								<p><span class="label label-danger">Obligatoire</span></p>
+								<p>Le fil d'Ariane est : <a href="https://www.canada.ca/fr.html">Accueil</a> > <a href="https://www.canada.ca/fr/gouvernement/min.html">Ministères et organismes</a>.</p>
+
+							</section>
+							<section>
+								<h3>Titre</h3>
+								<p><span class="label label-danger">Obligatoire</span></p>
+								<p>Utilisez le titre d’usage de l’institution indiqué dans le <a href="https://www.tbs-sct.gc.ca/hgw-cgf/oversight-surveillance/communications/fip-pcim/reg-fra.asp">Registre des titres d’usage</a>.</p>
+								<p>Utilisez le titre légal si le titre d’usage n’est pas disponible.</p>
+								<p>N'utilisez pas d’acronymes ou d’abréviations.</p>
+							</section>
+
+							<section>
+								<h3>Image</h3>
+								<p><span class="label label-info">Facultatif</span></p>
+								<p>La zone de 1200x726 derrière le H1 peut être utilisée pour une bannière ou une image. L'image n'a pas besoin d'occuper tout l'espace et peut être personnalisée au besoin.</p>
+								<p>L'image et le H1 doivent être visuellement distincts de la <a href="https://www.canada.ca/">page d'accueil de Canada.ca</a> afin d'éviter toute confusion entre la page d'accueil de l'institution et celle de Canada.ca.</p>
+								<p>Si vous n'utilisez pas d'image, l'arrière-plan devrait être blanc.</p>
+								<p><b>Variation:</b> Appliquez la classe <code>ip-cover-hide-mobile</code> en plus de <code>ip-cover-img</code> pour cacher l'image pour les appareils mobiles.</p>
+							</section>
+
+							<section>
+								<h3>Bouton vers une super-tâche</h3>
+								<p><span class="label label-info">Facultatif</span></p>
+								<p>N'incluez un bouton vers une super-tâche que s'il y a une tâche spécifique qui génère au moins un tiers des clics sur la page d'accueil de l'institution. Ceci est principalement destiné à faciliter la connexion à un compte.</p>
+							</section>
+
+						</details>
+					</div>
+				</div>
+			</div>
+		</div>
+
+
+		<section class="featured row opct-90">
+			<h2 class="wb-inv">En vedette</h2>
+			<div class="container">
+				<span class="h5"><a href="#">Lien en vedette [facultatif]</a></span>
+				<div class="row guidance-details">
+					<div class="col-md-8">
+						<details>
+							<summary><b>Directives : </b> lien en vedette <i class="fas fa-info-circle"></i></summary>
+							<p><span class="label label-info">Facultatif</span></p>
+							<p>Le lien en vedette est un lien court et descriptif que votre institution doit mettre en évidence. Il devrait être utilisé pour attirer l'attention sur des avertissements ou des avis.</p>
+							<p>N'incluez pas d'image dans cette section.</p>
+							<p>L'en-tête «&nbsp;En vedette» dans cette section doit avoir la classe <code>wb-inv</code> afin qu'il ne soit pas visible, mais qu'il soit tout de même présent pour des raisons sémantiques et pour les lecteurs d'écran.</p>
+						</details>
+					</div>
+				</div>
+			</div>
+		</section>
+
+		<section class="most-requested well well-sm brdr-0">
+			<div class="container">
+				<h2 class="mrgn-tp-md">En demande</h2>
+				<ul class="wb-eqht list-unstyled mrgn-tp-md mrgn-bttm-sm lst-spcd-2 list-responsive-3">
+					<!-- can use 'list-responsive' to get 4 column option -->
+					<li><a href="#">[Lien vers une tâche principale]</a></li>
+					<li><a href="#">[Lien vers une tâche principale]</a></li>
+					<li><a href="#">[Lien vers une tâche principale]</a></li>
+					<li><a href="#">[Lien vers une tâche principale]</a></li>
+					<li><a href="#">[Lien vers une tâche principale]</a></li>
+					<li><a href="#">[Lien vers une tâche principale]</a></li>
+				</ul>
+				<div class="row guidance-details">
+					<div class="col-md-8">
+						<details>
+							<summary><b>Directives : </b> En demande <i class="fas fa-info-circle"></i></summary>
+							<p><span class="label label-info">Facultatif</span></p>
+							<p>Présente les tâches principales spécifiques à l'institution.</p>
+							<p>Cette composante fournit des raccourcis vers les tâches les plus importantes de l'institution. Cependant, si toutes les tâches principales de l'institution sont déjà incluses en tant que liens directs sous «&nbsp;Services et renseignements&nbsp;», ne les répétez pas ici. Dans ce cas, vous pouvez choisir de ne pas inclure cette composante.</p>
+							<p><strong>Variations:</strong> remplacez la classe <code>list-responsive-3</code> pour <code>list-responsive</code> pour présenter cette section en 4 colonnes au lieu de 3.</p>
+						</details>
+					</div>
+				</div>
+			</div>
+		</section>
+
+		<div class="container">
+
+			<section class="gc-srvinfo col-md-12 mrgn-bttm-lg row">
+				<h2 class="wb-inv">Services et renseignements</h2>
+				<div class="row">
+					<div class="wb-eqht">
+						<section class="col-md-4">
+							<h3><a href="#">[Texte de l'hyperlien]</a></h3>
+							<p>Utilisez des verbes d'action ou énumérez simplement des mots-clés pour résumer les renseignements ou les tâches qui peuvent être accomplis sur la page à laquelle il renvoie.</p>
+						</section>
+						<section class="col-md-4">
+							<h3><a href="#">[Texte de l'hyperlien]</a></h3>
+							<p>Utilisez des verbes d'action ou énumérez simplement des mots-clés pour résumer les renseignements ou les tâches qui peuvent être accomplis sur la page à laquelle il renvoie.</p>
+						</section>
+						<section class="col-md-4">
+							<h3><a href="#">[Texte de l'hyperlien]</a></h3>
+							<p>Utilisez des verbes d'action ou énumérez simplement des mots-clés pour résumer les renseignements ou les tâches qui peuvent être accomplis sur la page à laquelle il renvoie.</p>
+						</section>
+
+						<section class="col-md-4">
+							<h3><a href="#">[Texte de l'hyperlien]</a></h3>
+							<p>Utilisez des verbes d'action ou énumérez simplement des mots-clés pour résumer les renseignements ou les tâches qui peuvent être accomplis sur la page à laquelle il renvoie.</p>
+						</section>
+						<section class="col-md-4">
+							<h3><a href="#">[Texte de l'hyperlien]</a></h3>
+							<p>Utilisez des verbes d'action ou énumérez simplement des mots-clés pour résumer les renseignements ou les tâches qui peuvent être accomplis sur la page à laquelle il renvoie.</p>
+						</section>
+						<section class="col-md-4">
+							<h3><a href="#">[Texte de l'hyperlien]</a></h3>
+							<p>Utilisez des verbes d'action ou énumérez simplement des mots-clés pour résumer les renseignements ou les tâches qui peuvent être accomplis sur la page à laquelle il renvoie.</p>
+						</section>
+
+						<section class="col-md-4">
+							<h3><a href="#">[Texte de l'hyperlien]</a></h3>
+							<p>Utilisez des verbes d'action ou énumérez simplement des mots-clés pour résumer les renseignements ou les tâches qui peuvent être accomplis sur la page à laquelle il renvoie.</p>
+						</section>
+						<section class="col-md-4">
+							<h3><a href="#">[Texte de l'hyperlien]</a></h3>
+							<p>Utilisez des verbes d'action ou énumérez simplement des mots-clés pour résumer les renseignements ou les tâches qui peuvent être accomplis sur la page à laquelle il renvoie.</p>
+						</section>
+						<section class="col-md-4">
+							<h3><a href="#">[Texte de l'hyperlien]</a></h3>
+							<p>Utilisez des verbes d'action ou énumérez simplement des mots-clés pour résumer les renseignements ou les tâches qui peuvent être accomplis sur la page à laquelle il renvoie.</p>
+						</section>
+						<div class="clearfix"></div>
+					</div>
+				</div>
+				<div class="row guidance-details">
+					<div class="col-md-8">
+						<details>
+							<summary><b>Directives : </b> Services et renseignements <i class="fas fa-info-circle"></i></summary>
+							<p><span class="label label-danger">Obligatoire</span></p>
+							<p>Dresse la liste des sujets ou des tâches principales spécifiques à l’institution.</p>
+							<p>L'en-tête «&nbsp;services et renseignements&nbsp;» dans cette section doit avoir la classe <code>wb-inv</code> afin qu'il ne soit pas visible, mais qu'il soit tout de même présent pour des raisons sémantiques et pour les lecteurs d'écran.</p>
+							<p><b>Variations:</b> Toutes les variations du modèle <a href="../configurations-conception-communes/services-renseignements.html">Services et renseignements</a> peuvent être utilisées dans cette section.</li>
+						</details>
+					</div>
+				</div>
+			</section>
+
+		</div>
+
+		<section class="most-requested well well-sm brdr-0">
+			<div class="container">
+				<div class="wb-eqht row">
+					<h2 class="col-lg-3 h3">Coordonnées</h2>
+					<span class="clearfix"></span>
+					<section class="col-lg-4 col-md-6 col-sm-6">
+						<h3 class="h5"><a href="#">Communiquer avec [institution]</a></h3>
+					</section>
+					<section class="col-lg-4 col-md-6 col-sm-6">
+						<h3 class="h5"><a href="#">[Tâche de contact 2]</a></h3>
+					</section>
+					<section class="col-lg-4 col-md-6 col-sm-6">
+						<h3 class="h5"><a href="#">[Tâche de contact 3]</a></h3>
+					</section>
+				</div>
+				<div class="row">
+
+					<section class="col-md-8 pull-left mrgn-bttm-lg">
+						<h2 class="h3">À propos de [Institution]</h2>
+						<div class="wb-eqht row">
+							<div class="col-md-6">
+								<section>
+									<h3 class="h5">
+										<a href="#">Mandat</a>
+									</h3>
+								</section>
+							</div>
+							<div class="col-md-6">
+								<section>
+									<h3 class="h5">
+										<a href="#">Structure organisationnelle</a>
+									</h3>
+								</section>
+							</div>
+							<div class="col-md-6">
+								<section>
+									<h3 class="h5">
+										<a href="#" rel="external">Transparence</a>
+									</h3>
+								</section>
+							</div>
+							<div class="col-md-6">
+								<section>
+									<h3 class="h5">
+										<a href="#" rel="external">Possibilités d'emploi</a>
+									</h3>
+								</section>
+							</div>
+							<div class="col-md-6">
+								<section>
+									<h3 class="h5">
+										<a href="#">Rapports</a>
+									</h3>
+								</section>
+							</div>
+							<div class="col-md-6">
+								<section>
+									<h3 class="h5">
+										<a href="#">Observation</a>
+									</h3>
+								</section>
+							</div>
+							<div class="col-md-6">
+								<section>
+									<h3 class="h5">
+										<a href="#">Avis de mesure d'exécution</a>
+									</h3>
+								</section>
+							</div>
+							<div class="col-md-6">
+								<section>
+									<h3 class="h5">
+										<a href="#">Lien institutionnel</a>
+									</h3>
+								</section>
+							</div>
+							<div class="col-md-6">
+								<section>
+									<h3 class="h5">
+										<a href="#">Lien institutionnel</a>
+									</h3>
+								</section>
+							</div>
+							<div class="col-md-6">
+								<section>
+									<h3 class="h5">En savoir plus:
+										<a href="#" rel="external">Au sujet de [institution]</a>
+									</h3>
+								</section>
+							</div>
+						</div>
+					</section>
+
+					<div class="col-md-4 col-sm-5 pull-right mobile-left">
+						<div class="visible-sm"></div>
+						<section class="lnkbx">
+							<h2 class="h3">Ministre</h2>
+							<p><a href="#">[(L'honorable) prénom et nom de famille]</a><br>
+								<small>Titre officiel du ministre</small></p>
+							<p><a href="#">[(L'honorable) prénom et nom de famille]</a><br>
+								<small>Titre officiel du ministre</small></p>
+							<p><a href="#">[(L'honorable) prénom et nom de famille]</a><br>
+								<small>Titre officiel du ministre</small></p>
+
+							<section class="row followus">
+								<h2 class="mrgn-tp-lg h3">Suivez</h2>
+								<br>
+								<ul>
+									<li><a href="https://www.facebook.com/canrevagency" class="facebook" rel="external"><span class="wb-inv">Facebook</span></a></li>
+									<li><a href="https://twitter.com/CanRevAgency" class="twitter" rel="external"><span class="wb-inv">Twitter</span></a></li>
+									<li><a href="https://www.youtube.com/user/CanRevAgency" class="youtube" rel="external"><span class="wb-inv">YouTube</span></a></li>
+									<li><a href="https://www.linkedin.com/company/cra-arc" class="linkedin" rel="external"><span class="wb-inv">LinkedIn</span></a></li>
+								</ul>
+							</section>
+						</section>
+					</div>
+					<div class="row guidance-details">
 						<div class="col-md-8">
 							<details>
 								<summary><b>Directives :</b> Coordonnées, À propos de l'institution, Ministres, et Médias sociaux <i class="fas fa-info-circle"></i></summary>
@@ -537,7 +547,7 @@
 
 								<section>
 									<h3>Ministre ou chef d'une institution</h3>
-									<p><span class="label label-danger">Obligatoire	</span></p>
+									<p><span class="label label-danger">Obligatoire </span></p>
 									<p>Fournit des liens menant soit au(x) ministre(s) de l’institution (y compris les ministres associés), soit au chef de l’institution.</p>
 									<p>Le texte est lié au profil ministériel approprié (voir les <a href="../modeles-obligatoire/pages-profil-ministres.html">pages de profil des ministres</a>). Le texte de l’hyperlien est le titre honorifique («&nbsp;L’honorable&nbsp;») et le prénom et nom du ou de la ministre ou du chef de l’institution.</p>
 									<p>Le texte sous le lien est le titre officiel du ministre ou du chef de l'institution.</p>
@@ -562,140 +572,145 @@
 					</div>
 
 
-      </div>
+				</div>
 
 
-    </div>
+			</div>
 
-  </section>
+		</section>
 
-  <!-- News bar start -->
-	<div class="container">
-		<div class="row col-lg-12">
-			<section class="col-md-4 wb-feeds limit-3 gc-nws">
-				<h2 class="h3">Nouvelles</h2>
+		<!-- News bar start -->
+		<div class="container">
+			<div class="row col-lg-12">
+				<section class="col-md-4 wb-feeds limit-3 gc-nws">
+					<h2 class="h3">Nouvelles</h2>
 
-				<!-- demonstrate the look - use json feed where applicable -->
-				<ul class="feeds-cont list-unstyled lst-spcd feed-active">
-					<li><a href="#">[Titre de nouvelle]</a><br> <small class="feeds-date">AAAA-MM-JJ HH:MM</small></li>
-					<li><a href="#">[Titre de nouvelle]</a><br> <small class="feeds-date">AAAA-MM-JJ HH:MM</small></li>
-					<li><a href="#">[Titre de nouvelle]</a><br> <small class="feeds-date">AAAA-MM-JJ HH:MM</small></li>
-				</ul>
-				<!-- json feed for news example
+					<!-- demonstrate the look - use json feed where applicable -->
+					<ul class="feeds-cont list-unstyled lst-spcd feed-active">
+						<li><a href="#">[Titre de nouvelle]</a><br> <small class="feeds-date">AAAA-MM-JJ HH:MM</small></li>
+						<li><a href="#">[Titre de nouvelle]</a><br> <small class="feeds-date">AAAA-MM-JJ HH:MM</small></li>
+						<li><a href="#">[Titre de nouvelle]</a><br> <small class="feeds-date">AAAA-MM-JJ HH:MM</small></li>
+					</ul>
+					<!-- json feed for news example
 				<ul class="feeds-cont list-unstyled lst-spcd">
 					<li> <a data-ajax="https://www.canada.ca/content/canadasite/api/nws/fds/en/web-feeds/revenue-agency.json" href="https://www.canada.ca/en/revenue-agency.atom.xml" rel="external">Canada Revenue Agency news items</a> </li>
 				</ul>-->
-				<p>En savoir plus: <a href="#" class="admin">Nouvelles de [Institution]</a></p>
+					<p>En savoir plus: <a href="#" class="admin">Nouvelles de [Institution]</a></p>
 
-			</section>
+				</section>
 
-			<section class="col-md-8 gc-prtts">
+				<section class="col-md-8 gc-prtts">
 
-				<h2 class="h3">En vedette</h2>
-				<div class="row wb-eqht">
-					<div class="col-md-6 mrgn-bttm-md">
-						<a class="figcaption hght-inhrt" href="#">
-							<figure class="well well-sm brdr-rds-0 hght-inhrt"><img class="img-responsive full-width" alt="#" src="https://wet-boew.github.io/themes-dist/GCWeb/img/360x203.png">
-								<figcaption class="h5">[Hyperlien de l'élément]</figcaption>
-								<p>Brève description de l'élément en vedette.</p>
-							</figure>
-						</a>
+					<h2 class="h3">En vedette</h2>
+					<div class="row wb-eqht">
+						<div class="col-md-6 mrgn-bttm-md">
+							<a class="figcaption hght-inhrt" href="#">
+								<figure class="well well-sm brdr-rds-0 hght-inhrt"><img class="img-responsive full-width" alt="#" src="https://wet-boew.github.io/themes-dist/GCWeb/img/360x203.png">
+									<figcaption class="h5">[Hyperlien de l'élément]</figcaption>
+									<p>Brève description de l'élément en vedette.</p>
+								</figure>
+							</a>
+						</div>
+						<div class="col-md-6 mrgn-bttm-md">
+							<a class="figcaption hght-inhrt" href="https://www.canada.ca/en/revenue-agency/campaigns/my-benefits-credits.html">
+								<figure class="well well-sm brdr-rds-0 hght-inhrt"><img class="img-responsive full-width" alt="#" src="https://wet-boew.github.io/themes-dist/GCWeb/img/360x203.png">
+									<figcaption class="h5">[Hyperlien de l'élement]</figcaption>
+									<p>Brève description de l'élément en vedette.</p>
+								</figure>
+							</a>
+						</div>
 					</div>
-					<div class="col-md-6 mrgn-bttm-md">
-						<a class="figcaption hght-inhrt" href="https://www.canada.ca/en/revenue-agency/campaigns/my-benefits-credits.html">
-							<figure class="well well-sm brdr-rds-0 hght-inhrt"><img class="img-responsive full-width" alt="#" src="https://wet-boew.github.io/themes-dist/GCWeb/img/360x203.png">
-								<figcaption class="h5">[Hyperlien de l'élement]</figcaption>
-								<p>Brève description de l'élément en vedette.</p>
-							</figure>
-						</a>
+				</section>
+			</div>
+
+			<div class="row guidance-details">
+				<div class="col-md-8">
+					<details>
+						<summary><b>Directives :</b> Nouvelles et En vedette <i class="fas fa-info-circle"></i></summary>
+						<p><span class="label label-info">Facultatif</span></p>
+						<p>Utilisez la version bêta du <a href="../configurations-conception-communes/nouveautes.html">modèle Nouveautés</a>.</p>
+					</details>
+				</div>
+			</div>
+
+
+			<div class="row pagedetails">
+				<div class="col-sm-6 col-lg-4 mrgn-tp-sm">
+					<div class="panel-pane pane-block pane-bean-report-problem-button">
+						<div class="pane-content">
+							<section>
+								<div class="field field-name-field-bean-wetkit-body field-type-text-long field-label-hidden">
+									<div class="field-items">
+										<div class="field-item even"><a class="btn btn-default btn-block" href="https://www.canada.ca/fr/signaler-probleme.html">Signaler un problème sur cette page</a></div>
+									</div>
+								</div>
+							</section>
+						</div>
 					</div>
 				</div>
-			</section>
-		</div>
 
-		<div class="row guidance-details">
-			<div class="col-md-8">
-				<details>
-					<summary><b>Directives :</b> Nouvelles et En vedette <i class="fas fa-info-circle"></i></summary>
-					<p><span class="label label-info">Facultatif</span></p>
-					<p>Utilisez la version bêta du <a href="../configurations-conception-communes/nouveautes.html">modèle Nouveautés</a>.</p>
-				</details>
+				<div class="col-sm-3 mrgn-tp-sm pull-right">
+					<div class="wb-share" data-wb-share='{&#34;lnkClass&#34;: &#34;btn btn-default btn-block&#34;}'></div>
+				</div>
+
+
+				<div class="datemod col-xs-12 mrgn-tp-lg">
+					<dl id="wb-dtmd">
+						<dt>Date de modification :</dt>
+						<dd><time property="dateModified">2019-11-28</time></dd>
+					</dl>
+				</div>
+
+			</div>
+	</main>
+	</div>
+
+
+
+
+
+
+
+
+	<footer id="wb-info">
+		<div class="landscape">
+			<nav class="container wb-navcurr">
+				<h2 class="wb-inv">Au sujet du gouvernement</h2>
+				<ul class="list-unstyled colcount-sm-2 colcount-md-3">
+					<li><a href="https://www.canada.ca/fr/contact.html">Contactez-nous</a></li>
+					<li><a href="https://www.canada.ca/fr/gouvernement/min.html">Ministères et organismes</a></li>
+					<li><a href="https://www.canada.ca/fr/gouvernement/fonctionpublique.html">Fonction publique et force militaire</a></li>
+					<li><a href="https://www.canada.ca/fr/nouvelles.html">Nouvelles</a></li>
+					<li><a href="https://www.canada.ca/fr/gouvernement/systeme/lois.html">Traités, lois et règlements</a></li>
+					<li><a href="https://www.canada.ca/fr/transparence/rapports.html">Rapports à l'échelle du gouvernement</a></li>
+					<li><a href="https://pm.gc.ca/fra">Premier ministre</a></li>
+					<li><a href="https://www.canada.ca/fr/gouvernement/systeme.html">Comment le gouvernement fonctionne</a></li>
+					<li><a href="https://ouvert.canada.ca/">Gouvernement ouvert</a></li>
+				</ul>
+			</nav>
+		</div>
+		<div class="brand">
+			<div class="container">
+				<div class="row">
+					<nav class="col-md-9 col-lg-10 ftr-urlt-lnk">
+						<h2 class="wb-inv">À propos du site</h2>
+						<ul>
+							<li><a href="https://www.canada.ca/fr/sociaux.html">Médias sociaux</a></li>
+							<li><a href="https://www.canada.ca/fr/mobile.html">Applications mobiles</a></li>
+							<li><a href="https://www1.canada.ca/fr/nouveausite.html">À propos de Canada.ca</a></li>
+							<li><a href="https://www.canada.ca/fr/transparence/avis.html">Avis</a></li>
+							<li><a href="https://www.canada.ca/fr/transparence/confidentialite.html">Confidentialité</a></li>
+						</ul>
+					</nav>
+					<div class="col-xs-6 visible-sm visible-xs tofpg">
+						<a href="#wb-cont">Haut de la page <span class="glyphicon glyphicon-chevron-up"></span></a>
+					</div>
+					<div class="col-xs-6 col-md-3 col-lg-2 text-right">
+						<img src="http://www.canada.ca/etc/designs/canada/wet-boew/assets/wmms-blk.svg" alt="Symbole du gouvernement du Canada">
+					</div>
+				</div>
 			</div>
 		</div>
-
-
-<div class="row pagedetails">
-<div class="col-sm-6 col-lg-4 mrgn-tp-sm">
-<div class="panel-pane pane-block pane-bean-report-problem-button"  >
-<div class="pane-content">
-<section>
-<div class="field field-name-field-bean-wetkit-body field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><a class="btn btn-default btn-block" href="https://www.canada.ca/fr/signaler-probleme.html">Signaler un problème sur cette page</a></div></div></div></section>
-</div>
-</div>
-</div>
-
-		<div class="col-sm-3 mrgn-tp-sm pull-right">
-		<div class="wb-share" data-wb-share='{&#34;lnkClass&#34;: &#34;btn btn-default btn-block&#34;}'></div>
-</div>
-
-
-<div class="datemod col-xs-12 mrgn-tp-lg">
-		<dl id="wb-dtmd">
-<dt>Date de modification :</dt>
-<dd><time property="dateModified">2019-11-28</time></dd>
-</dl>
-</div>
-
-</div>
-</main>
-	</div>
-
-
-
-
-
-
-
-
-<footer id="wb-info">
-<div class="landscape">
-<nav class="container wb-navcurr">
-<h2 class="wb-inv">Au sujet du gouvernement</h2>
-<ul class="list-unstyled colcount-sm-2 colcount-md-3">
-<li><a href="https://www.canada.ca/fr/contact.html">Contactez-nous</a></li>
-<li><a href="https://www.canada.ca/fr/gouvernement/min.html">Ministères et organismes</a></li>
-<li><a href="https://www.canada.ca/fr/gouvernement/fonctionpublique.html">Fonction publique et force militaire</a></li>
-<li><a href="https://www.canada.ca/fr/nouvelles.html">Nouvelles</a></li>
-<li><a href="https://www.canada.ca/fr/gouvernement/systeme/lois.html">Traités, lois et règlements</a></li>
-<li><a href="https://www.canada.ca/fr/transparence/rapports.html">Rapports à l'échelle du gouvernement</a></li>
-<li><a href="https://pm.gc.ca/fra">Premier ministre</a></li>
-<li><a href="https://www.canada.ca/fr/gouvernement/systeme.html">Comment le gouvernement fonctionne</a></li>
-<li><a href="https://ouvert.canada.ca/">Gouvernement ouvert</a></li>
-</ul>
-</nav>
-</div>
-<div class="brand">
-<div class="container">
-<div class="row">
-<nav class="col-md-9 col-lg-10 ftr-urlt-lnk">
-<h2 class="wb-inv">À propos du site</h2>
-<ul>
-<li><a href="https://www.canada.ca/fr/sociaux.html">Médias sociaux</a></li>
-<li><a href="https://www.canada.ca/fr/mobile.html">Applications mobiles</a></li>
-<li><a href="https://www1.canada.ca/fr/nouveausite.html">À propos de Canada.ca</a></li>
-<li><a href="https://www.canada.ca/fr/transparence/avis.html">Avis</a></li>
-<li><a href="https://www.canada.ca/fr/transparence/confidentialite.html">Confidentialité</a></li>
-</ul>
-</nav>
-<div class="col-xs-6 visible-sm visible-xs tofpg">
-<a href="#wb-cont">Haut de la page <span class="glyphicon glyphicon-chevron-up"></span></a>
-</div>
-	<div class="col-xs-6 col-md-3 col-lg-2 text-right">
-	<img src="http://www.canada.ca/etc/designs/canada/wet-boew/assets/wmms-blk.svg" alt="Symbole du gouvernement du Canada">
-	</div>
-	</div>
-	</div>
-	</div>
 	</footer>
 	<!--[if gte IE 9 | !IE ]><!-->
 	<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.js"></script>
@@ -707,7 +722,8 @@
 			<![endif]-->
 	<script src="https://www.canada.ca/etc/designs/canada/wet-boew/js/theme.min.js"></script>
 	<script>
-	document.getElementById('submissionPage').value = location.href;
-</script>
+		document.getElementById('submissionPage').value = location.href;
+	</script>
 </body>
-	</html>
+
+</html>

--- a/mise-en-page/accueil-institution-ng.html
+++ b/mise-en-page/accueil-institution-ng.html
@@ -3,6 +3,7 @@
 <!--[if gt IE 8]><!-->
 <html class="no-js" lang="fr" dir="ltr">
 <!--<![endif]-->
+
 <head>
   <meta charset="utf-8">
   <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
@@ -28,10 +29,10 @@
     <link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/wet-boew/css/noscript.min.css" /></noscript>
   <script>
     (function (i, s, o, g, r, a, m) {
-    i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
-      (i[r].q = i[r].q || []).push(arguments)
-    }, i[r].l = 1 * new Date(); a = s.createElement(o),
-      m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
+      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
+        (i[r].q = i[r].q || []).push(arguments)
+      }, i[r].l = 1 * new Date(); a = s.createElement(o),
+        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
     })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
     ga('create', 'UA-105628416-1', 'auto');
     ga('send', 'pageview');
@@ -45,6 +46,7 @@
     gtag('config', 'UA-105628416-3');
   </script>
 </head>
+
 <body class="cnt-wdth-lmtd" vocab="http://schema.org/" typeof="WebPage">
   <ul id="wb-tphp">
     <li class="wb-slc">
@@ -448,4 +450,5 @@
     document.getElementById('submissionPage').value = location.href;
   </script>
 </body>
+
 </html>

--- a/mise-en-page/transparence_directives.html
+++ b/mise-en-page/transparence_directives.html
@@ -1,224 +1,229 @@
-
-<!DOCTYPE html><!--[if lt IE 9]><html class="no-js lt-ie9" lang="en" dir="ltr"><![endif]--><!--[if gt IE 8]><!-->
+<!DOCTYPE html>
+<!--[if lt IE 9]><html class="no-js lt-ie9" lang="en" dir="ltr"><![endif]-->
+<!--[if gt IE 8]><!-->
 <html class="no-js" lang="fr" dir="ltr">
 <!--<![endif]-->
+
 <head>
-<meta charset="utf-8">
-<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+  <meta charset="utf-8">
+  <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
 		wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
-		<title>Gabarit de page de transparence avec directives - Canada.ca</title>
+  <title>Gabarit de page de transparence avec directives - Canada.ca</title>
 
-		<meta content="width=device-width,initial-scale=1" name="viewport">
+  <meta content="width=device-width,initial-scale=1" name="viewport">
 
-		<!--[if gte IE 9 | !IE ]><!-->
-		<link href="https://www.canada.ca/etc/designs/canada/wet-boew/assets/favicon.ico" rel="icon" type="image/x-icon">
-		<link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/css/theme.min.css">
-		<link rel="stylesheet" href="../css/custom.css">
-		<link rel="stylesheet" href="../css/ip.css">
-		<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css">
-<!--<![endif]-->
-<!--[if lt IE 9]>
+  <!--[if gte IE 9 | !IE ]><!-->
+  <link href="https://www.canada.ca/etc/designs/canada/wet-boew/assets/favicon.ico" rel="icon" type="image/x-icon">
+  <link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/css/theme.min.css">
+  <link rel="stylesheet" href="../css/custom.css">
+  <link rel="stylesheet" href="../css/ip.css">
+  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css">
+  <!--<![endif]-->
+  <!--[if lt IE 9]>
 		<link href="./GCWeb/assets/favicon.ico" rel="shortcut icon" />
 
 		<link rel="stylesheet" href="http://wet-boew.github.io/themes-dist/GCWeb/GCWeb/css/ie8-theme.min.css" />
 		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
 		<script src="./wet-boew/js/ie8-wet-boew.min.js"></script>
 		<![endif]-->
-<!--[if lte IE 9]>
+  <!--[if lte IE 9]>
 
 
 		<![endif]-->
-<noscript><link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/wet-boew/css/noscript.min.css" /></noscript>
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+  <noscript>
+    <link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/wet-boew/css/noscript.min.css" /></noscript>
+  <script>
+    (function (i, s, o, g, r, a, m) {
+    i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
+      (i[r].q = i[r].q || []).push(arguments)
+    }, i[r].l = 1 * new Date(); a = s.createElement(o),
+      m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
+    })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
 
-  ga('create', 'UA-105628416-1', 'auto');
-  ga('send', 'pageview');
+    ga('create', 'UA-105628416-1', 'auto');
+    ga('send', 'pageview');
 
-</script>
+  </script>
 
-<!-- Global site tag (gtag.js) - Google Analytics -->
+  <!-- Global site tag (gtag.js) - Google Analytics -->
 
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-105628416-3"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-105628416-3"></script>
 
-<script>
+  <script>
 
-  window.dataLayer = window.dataLayer || [];
+    window.dataLayer = window.dataLayer || [];
 
-  function gtag(){dataLayer.push(arguments);}
+    function gtag() { dataLayer.push(arguments); }
 
-  gtag('js', new Date());
+    gtag('js', new Date());
 
 
 
-  gtag('config', 'UA-105628416-3');
+    gtag('config', 'UA-105628416-3');
 
-</script>
+  </script>
 </head>
+
 <body vocab="http://schema.org/" typeof="WebPage">
-<ul id="wb-tphp">
-<li class="wb-slc">
-	<a class="wb-sl" href="#wb-cont">Passer au contenu principal</a>
-</li>
-<li class="wb-slc">
-	<a class="wb-sl" href="#wb-info">Passer à «&#160;Au sujet du gouvernement&#160;»</a>
-</li>
-</ul>
-<header>
-<div id="wb-bnr" class="container">
-<section id="wb-lng" class="text-right">
-<h2 class="wb-inv">Sélection de la langue</h2>
-<div class="row">
-<div class="col-md-12">
-<ul class="list-inline margin-bottom-none">
-	<li><a lang="en" href="https://design.canada.ca/coded-layout/transparency_guidance.html">English</a></li>
-</ul>
-</div>
-</div>
-</section>
-<div class="row">
-<div class="brand col-xs-5 col-md-4">
-<a href="https://www.canada.ca/fr.html"><img src="http://www.canada.ca/etc/designs/canada/wet-boew/assets/sig-blk-fr.svg" alt=""><span class="wb-inv"> Gouvernement du Canada / <span lang="en">Government of Canada</span></span></a>
-</div>
-<section id="wb-srch" class="col-lg-8 text-right">
-	<h2>Recherche</h2>
-<form action="https://recherche-search.gc.ca/rGs/s_r?#wb-land" method="get" role="search" class="form-inline">
+  <ul id="wb-tphp">
+    <li class="wb-slc">
+      <a class="wb-sl" href="#wb-cont">Passer au contenu principal</a>
+    </li>
+    <li class="wb-slc">
+      <a class="wb-sl" href="#wb-info">Passer à «&#160;Au sujet du gouvernement&#160;»</a>
+    </li>
+  </ul>
+  <header>
+    <div id="wb-bnr" class="container">
+      <section id="wb-lng" class="text-right">
+        <h2 class="wb-inv">Sélection de la langue</h2>
+        <div class="row">
+          <div class="col-md-12">
+            <ul class="list-inline margin-bottom-none">
+              <li><a lang="en" href="https://design.canada.ca/coded-layout/transparency_guidance.html">English</a></li>
+            </ul>
+          </div>
+        </div>
+      </section>
+      <div class="row">
+        <div class="brand col-xs-5 col-md-4">
+          <a href="https://www.canada.ca/fr.html"><img src="http://www.canada.ca/etc/designs/canada/wet-boew/assets/sig-blk-fr.svg" alt=""><span class="wb-inv"> Gouvernement du Canada / <span lang="en">Government of Canada</span></span></a>
+        </div>
+        <section id="wb-srch" class="col-lg-8 text-right">
+          <h2>Recherche</h2>
+          <form action="https://recherche-search.gc.ca/rGs/s_r?#wb-land" method="get" role="search" class="form-inline">
 
-<div class="form-group">
+            <div class="form-group">
 
-	<label for="wb-srch-q" class="wb-inv">Rechercher dans Canada.ca</label>
+              <label for="wb-srch-q" class="wb-inv">Rechercher dans Canada.ca</label>
 
-	<input id="wb-srch-q" list="wb-srch-q-ac" class="wb-srch-q form-control" name="q" type="search" value="" size="34" maxlength="170" placeholder="Rechercher dans Canada.ca">
+              <input id="wb-srch-q" list="wb-srch-q-ac" class="wb-srch-q form-control" name="q" type="search" value="" size="34" maxlength="170" placeholder="Rechercher dans Canada.ca">
 
-<input name="st" value="s" type="hidden"/>
+              <input name="st" value="s" type="hidden" />
 
-<input name="num" value="10" type="hidden"/>
+              <input name="num" value="10" type="hidden" />
 
-<input name="langs" value="fra" type="hidden"/>
+              <input name="langs" value="fra" type="hidden" />
 
-<input name="st1rt" value="0" type="hidden">
+              <input name="st1rt" value="0" type="hidden">
 
-<input name="s5bm3ts21rch" value="x" type="hidden"/>
+              <input name="s5bm3ts21rch" value="x" type="hidden" />
 
-<datalist id="wb-srch-q-ac">
+              <datalist id="wb-srch-q-ac">
 
-<!--[if lte IE 9]><select><![endif]-->
+                <!--[if lte IE 9]><select><![endif]-->
 
-<!--[if lte IE 9]></select><![endif]-->
+                <!--[if lte IE 9]></select><![endif]-->
 
-</datalist>
+              </datalist>
 
-</div>
+            </div>
 
-<div class="form-group submit">
+            <div class="form-group submit">
 
-	<button type="submit" id="wb-srch-sub" class="btn btn-primary btn-small" name="wb-srch-sub"><span class="glyphicon-search glyphicon"></span><span class="wb-inv">Recherche</span></button>
-
-
-</div>
-
-</form>
+              <button type="submit" id="wb-srch-sub" class="btn btn-primary btn-small" name="wb-srch-sub"><span class="glyphicon-search glyphicon"></span><span class="wb-inv">Recherche</span></button>
 
 
-</section>
-</div>
-</div>
-<nav class="gweb-v2 gcweb-menu" typeof="SiteNavigationElement">
-<div class="container">
-<h2 class="wb-inv">Menu</h2>
-<button type="button" aria-haspopup="true" aria-controls="gc-mnu" aria-expanded="false">Menu<span class="wb-inv"> principal</span> <span class="expicon glyphicon glyphicon-chevron-down"></span></button>
-<ul id="gc-mnu" role="menu" aria-orientation="vertical" data-ajax-replace="https://www.canada.ca/content/dam/canada/sitemenu/sitemenu-v2-fr.html">
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/jobs.html">Emplois et milieu de travail</a></li>
+            </div>
 
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/immigration-citizenship.html">Immigration et citoyenneté</a></li>
+          </form>
 
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://voyage.gc.ca/">Voyage et tourisme</a></li>
 
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/entreprises.html">Entreprises et industrie</a></li>
+        </section>
+      </div>
+    </div>
+    <nav class="gweb-v2 gcweb-menu" typeof="SiteNavigationElement">
+      <div class="container">
+        <h2 class="wb-inv">Menu</h2>
+        <button type="button" aria-haspopup="true" aria-controls="gc-mnu" aria-expanded="false">Menu<span class="wb-inv"> principal</span> <span class="expicon glyphicon glyphicon-chevron-down"></span></button>
+        <ul id="gc-mnu" role="menu" aria-orientation="vertical" data-ajax-replace="https://www.canada.ca/content/dam/canada/sitemenu/sitemenu-v2-fr.html">
+          <li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/jobs.html">Emplois et milieu de travail</a></li>
 
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/benefits.html">Prestations</a></li>
+          <li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/immigration-citizenship.html">Immigration et citoyenneté</a></li>
 
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/sante.html">Santé</a></li>
+          <li role="none presentation"><a role="menuitem" tabindex="-1" href="https://voyage.gc.ca/">Voyage et tourisme</a></li>
 
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/impots.html">Impôts</a></li>
+          <li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/entreprises.html">Entreprises et industrie</a></li>
 
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/environnement.html">Environnement et ressources naturelles</a></li>
+          <li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/benefits.html">Prestations</a></li>
 
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/defense.html">Sécurité nationale et défense</a></li>
+          <li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/sante.html">Santé</a></li>
 
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/culture.html">Culture, histoire et sport</a></li>
+          <li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/impots.html">Impôts</a></li>
 
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/police.html">Services de police, justice et urgences</a></li>
+          <li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/environnement.html">Environnement et ressources naturelles</a></li>
 
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/transport.html">Transport et infrastructure</a></li>
+          <li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/defense.html">Sécurité nationale et défense</a></li>
 
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="http://international.gc.ca/world-monde/index.aspx?lang=fra">Canada et le monde</a></li>
+          <li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/culture.html">Culture, histoire et sport</a></li>
 
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/finance.html">Argent et finances</a></li>
+          <li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/police.html">Services de police, justice et urgences</a></li>
 
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/science.html">Science et innovation</a></li>
+          <li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/transport.html">Transport et infrastructure</a></li>
 
-</ul>
-</div>
-</nav>
-<nav id="wb-bc" property="breadcrumb">
-<h2>Vous êtes ici :</h2>
-<div class="container">
-<ol class="breadcrumb">
-	<li><a href='https://www.canada.ca/fr.html'>Accueil</a></li>
-	<li><a href='https://www.canada.ca/fr/gouvernement/a-propos.html'>À propos de Canada.ca</a></li>
-<li><a href='https://www.canada.ca/fr/gouvernement/a-propos/systeme-conception.html'>Système de conception de Canada.ca</a></li>
-	<li><a href='https://www.canada.ca/fr/gouvernement/a-propos/systeme-conception/bibliotheque-modeles.html'>Bibliothèque de modèles et de configurations de conception</a></li>
-	<li><a href='https://www.canada.ca/fr/gouvernement/a-propos/systeme-conception/bibliotheque-modeles.html'>Page d'accueil institutionnelle</a></li>
-</ol>
-</div>
-</nav>
-</header>
+          <li role="none presentation"><a role="menuitem" tabindex="-1" href="http://international.gc.ca/world-monde/index.aspx?lang=fra">Canada et le monde</a></li>
 
-<style> /* to move later */
+          <li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/finance.html">Argent et finances</a></li>
 
-/* added to detail summaries inside the code to remove the bottom spacing */
-.pattern-demo-code-ex details {
-	margin-bottom: 0px !important;
-}
+          <li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/science.html">Science et innovation</a></li>
 
-.pattern-demo-code-ex .featured {
-	margin-left: .07em !important;
-	margin-right: .07em !important;
-}
+        </ul>
+      </div>
+    </nav>
+    <nav id="wb-bc" property="breadcrumb">
+      <h2>Vous êtes ici :</h2>
+      <div class="container">
+        <ol class="breadcrumb">
+          <li><a href='https://www.canada.ca/fr.html'>Accueil</a></li>
+          <li><a href='https://www.canada.ca/fr/gouvernement/a-propos.html'>À propos de Canada.ca</a></li>
+          <li><a href='https://www.canada.ca/fr/gouvernement/a-propos/systeme-conception.html'>Système de conception de Canada.ca</a></li>
+          <li><a href='https://www.canada.ca/fr/gouvernement/a-propos/systeme-conception/bibliotheque-modeles.html'>Bibliothèque de modèles et de configurations de conception</a></li>
+          <li><a href='https://www.canada.ca/fr/gouvernement/a-propos/systeme-conception/bibliotheque-modeles.html'>Page d'accueil institutionnelle</a></li>
+        </ol>
+      </div>
+    </nav>
+  </header>
 
-/* .pattern-demo-code-ex .gc-prtts {
+  <style>
+    /* to move later */
+
+    /* added to detail summaries inside the code to remove the bottom spacing */
+    .pattern-demo-code-ex details {
+      margin-bottom: 0px !important;
+    }
+
+    .pattern-demo-code-ex .featured {
+      margin-left: .07em !important;
+      margin-right: .07em !important;
+    }
+
+    /* .pattern-demo-code-ex .gc-prtts {
 	width: 99%;
 } */
 
-.pattern-demo {
-	padding: 0px !important;
-	margin: 0px !important;
-	border: none !important;
-}
+    .pattern-demo {
+      padding: 0px !important;
+      margin: 0px !important;
+      border: none !important;
+    }
 
-.pattern-demo-code-ex {
-	margin-left: -35px !important;
-	margin-right: -35px !important;
-}
+    .pattern-demo-code-ex {
+      margin-left: -35px !important;
+      margin-right: -35px !important;
+    }
 
-.guidance-details details, .guidance-details summary, .guidance-details details summary:focus, .guidance-details details summary:hover {
-	background-color: white;
-}
-
-</style>
-</div>
-
-
-
-</div>
+    .guidance-details details,
+    .guidance-details summary,
+    .guidance-details details summary:focus,
+    .guidance-details details summary:hover {
+      background-color: white;
+    }
+  </style>
+  </div>
 
 
 
-
+  </div>
 
 
 
@@ -229,33 +234,37 @@
 
 
 
-<!--/* Hide Nav; Hide Right Rail /*-->
 
-<main property="mainContentOfPage" typeof="WebPageElement" class="container">
-<p><a class="btn btn-primary" href="./transparence_ng.html">Enlever les directives</a>  <a class="btn btn-default" href="../modeles-recommandes/transparence.html">Retourner à la page du modèle</a></p>
-<h1 property="name" id="wb-cont">Transparence: [Institution]</h1>
-<p class="pagetag">Divulgation proactive de l’information de [institution], qui est rendue publique afin que la population canadienne et le Parlement soient mieux en mesure de demander des comptes au gouvernement et aux représentants du secteur public.</p>
-<div class="row guidance-details">
-			<div class="col-md-8">
-				<details>
-					<summary><strong>Directives :</strong> Titre de page et introduction <i class="fas fa-info-circle"></i></summary>
 
-					<section>
-						<h3>Title</h3>
-						<p>Utilisez le titre d’usage de l’institution indiqué dans le <a href="https://www.tbs-sct.gc.ca/hgw-cgf/oversight-surveillance/communications/fip-pcim/reg-fra.asp">Registre des titres d’usage</a>.</p>
-						<p>Utilisez le titre légal si le titre d’usage n’est pas disponible.</p>
-						<p>N'utilisez pas d’acronymes ou d’abréviations.</p>
-					</section>
 
-					<section>
-						<h3>Texte d'introduction</h3>
-						<p>Utilisez le texte d'introduction ou ajustez-le en fonction de votre situation.</p>
-						<p>Le texte d'introduction doit être court.</p>
-					</section>
 
-				</details>
-			</div>
-		</div>
+  <!--/* Hide Nav; Hide Right Rail /*-->
+
+  <main property="mainContentOfPage" typeof="WebPageElement" class="container">
+    <p><a class="btn btn-primary" href="./transparence_ng.html">Enlever les directives</a> <a class="btn btn-default" href="../modeles-recommandes/transparence.html">Retourner à la page du modèle</a></p>
+    <h1 property="name" id="wb-cont">Transparence: [Institution]</h1>
+    <p class="pagetag">Divulgation proactive de l’information de [institution], qui est rendue publique afin que la population canadienne et le Parlement soient mieux en mesure de demander des comptes au gouvernement et aux représentants du secteur public.</p>
+    <div class="row guidance-details">
+      <div class="col-md-8">
+        <details>
+          <summary><strong>Directives :</strong> Titre de page et introduction <i class="fas fa-info-circle"></i></summary>
+
+          <section>
+            <h3>Title</h3>
+            <p>Utilisez le titre d’usage de l’institution indiqué dans le <a href="https://www.tbs-sct.gc.ca/hgw-cgf/oversight-surveillance/communications/fip-pcim/reg-fra.asp">Registre des titres d’usage</a>.</p>
+            <p>Utilisez le titre légal si le titre d’usage n’est pas disponible.</p>
+            <p>N'utilisez pas d’acronymes ou d’abréviations.</p>
+          </section>
+
+          <section>
+            <h3>Texte d'introduction</h3>
+            <p>Utilisez le texte d'introduction ou ajustez-le en fonction de votre situation.</p>
+            <p>Le texte d'introduction doit être court.</p>
+          </section>
+
+        </details>
+      </div>
+    </div>
     <section>
       <div class="row wb-eqht mrgn-bttm-md">
         <div class="col-md-4">
@@ -334,19 +343,19 @@
           </section>
         </div>
       </div>
-			<div class="row guidance-details">
-		 <div class="col-md-8">
-			 <details>
-				 <summary><strong>Directives :</strong> Services et renseignements <i class="fas fa-info-circle"></i></summary>
+      <div class="row guidance-details">
+        <div class="col-md-8">
+          <details>
+            <summary><strong>Directives :</strong> Services et renseignements <i class="fas fa-info-circle"></i></summary>
 
-				 <section>
-					 <p>Modifie les éléments de cette section en fonction de vos besoins. </p>
-					 <p>Utilisez le modèle <a href="../configurations-conception-communes/services-renseignements.html">Services et renseignements</a>.</li>
-				 </section>
+            <section>
+              <p>Modifie les éléments de cette section en fonction de vos besoins. </p>
+              <p>Utilisez le modèle <a href="../configurations-conception-communes/services-renseignements.html">Services et renseignements</a>.</li>
+            </section>
 
-			 </details>
-		 </div>
-		 </div>
+          </details>
+        </div>
+      </div>
     </section>
     <section>
       <div>
@@ -363,50 +372,53 @@
           </div>
         </div>
       </div>
-			<div class="row guidance-details">
-		<div class="col-md-8">
-			<details>
-				<summary><strong>Directives :</strong> demandes d'<abbr title="Accès à l’information et protection des renseignements personnels"><abbr title="Accès à l’information et protection des renseignements personnels">AIPRP</abbr></abbr> <i class="fas fa-info-circle"></i></summary>
+      <div class="row guidance-details">
+        <div class="col-md-8">
+          <details>
+            <summary><strong>Directives :</strong> demandes d'<abbr title="Accès à l’information et protection des renseignements personnels"><abbr title="Accès à l’information et protection des renseignements personnels">AIPRP</abbr></abbr> <i class="fas fa-info-circle"></i></summary>
 
-				<section>
-					<p>Liez le bouton «&nbsp;Faites une demande d'<abbr title="Accès à l’information et protection des renseignements personnels">AIPRP</abbr>&nbsp;» à une page dans laquelle les gens peuvent faire une demande d'AIRPP au sujet de votre institution.</p>
-					<p>Liez le bouton «&nbsp;Trouvez une demande précédente d'<abbr title="Accès à l’information et protection des renseignements personnels">AIPRP</abbr>&nbsp;» au portail du gouvernement ouvert. Vous pouvez lier à une liste pré-filtrée pour votre institution.</li>
-				</section>
+            <section>
+              <p>Liez le bouton «&nbsp;Faites une demande d'<abbr title="Accès à l’information et protection des renseignements personnels">AIPRP</abbr>&nbsp;» à une page dans laquelle les gens peuvent faire une demande d'AIRPP au sujet de votre institution.</p>
+              <p>Liez le bouton «&nbsp;Trouvez une demande précédente d'<abbr title="Accès à l’information et protection des renseignements personnels">AIPRP</abbr>&nbsp;» au portail du gouvernement ouvert. Vous pouvez lier à une liste pré-filtrée pour votre institution.</li>
+            </section>
 
-			</details>
-		</div>
-	</div>
+          </details>
+        </div>
+      </div>
     </section>
-  </section>
+    </section>
 
 
 
-<div class="row pagedetails">
-<div class="col-sm-6 col-lg-4 mrgn-tp-sm">
-<div class="panel-pane pane-block pane-bean-report-problem-button"  >
-<div class="pane-content">
-<section>
-<div class="field field-name-field-bean-wetkit-body field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><a class="btn btn-default btn-block" href="https://www.canada.ca/fr/signaler-probleme.html">Signaler un problème sur cette page</a></div></div></div></section>
-</div>
-</div>
-</div>
+    <div class="row pagedetails">
+      <div class="col-sm-6 col-lg-4 mrgn-tp-sm">
+        <div class="panel-pane pane-block pane-bean-report-problem-button">
+          <div class="pane-content">
+            <section>
+              <div class="field field-name-field-bean-wetkit-body field-type-text-long field-label-hidden">
+                <div class="field-items">
+                  <div class="field-item even"><a class="btn btn-default btn-block" href="https://www.canada.ca/fr/signaler-probleme.html">Signaler un problème sur cette page</a></div>
+                </div>
+              </div>
+            </section>
+          </div>
+        </div>
+      </div>
 
-		<div class="col-sm-3 mrgn-tp-sm pull-right">
-		<div class="wb-share" data-wb-share='{&#34;lnkClass&#34;: &#34;btn btn-default btn-block&#34;}'></div>
-</div>
-
-
-<div class="datemod col-xs-12 mrgn-tp-lg">
-		<dl id="wb-dtmd">
-<dt>Date de modification :</dt>
-<dd><time property="dateModified">2019-11-28</time></dd>
-</dl>
-</div>
-
-</div>
-</main>
+      <div class="col-sm-3 mrgn-tp-sm pull-right">
+        <div class="wb-share" data-wb-share='{&#34;lnkClass&#34;: &#34;btn btn-default btn-block&#34;}'></div>
+      </div>
 
 
+      <div class="datemod col-xs-12 mrgn-tp-lg">
+        <dl id="wb-dtmd">
+          <dt>Date de modification :</dt>
+          <dd><time property="dateModified">2019-11-28</time></dd>
+        </dl>
+      </div>
+
+    </div>
+  </main>
 
 
 
@@ -414,57 +426,60 @@
 
 
 
-<footer id="wb-info">
-<div class="landscape">
-<nav class="container wb-navcurr">
-<h2 class="wb-inv">Au sujet du gouvernement</h2>
-<ul class="list-unstyled colcount-sm-2 colcount-md-3">
-<li><a href="https://www.canada.ca/fr/contact.html">Contactez-nous</a></li>
-<li><a href="https://www.canada.ca/fr/gouvernement/min.html">Ministères et organismes</a></li>
-<li><a href="https://www.canada.ca/fr/gouvernement/fonctionpublique.html">Fonction publique et force militaire</a></li>
-<li><a href="https://www.canada.ca/fr/nouvelles.html">Nouvelles</a></li>
-<li><a href="https://www.canada.ca/fr/gouvernement/systeme/lois.html">Traités, lois et règlements</a></li>
-<li><a href="https://www.canada.ca/fr/transparence/rapports.html">Rapports à l'échelle du gouvernement</a></li>
-<li><a href="https://pm.gc.ca/fra">Premier ministre</a></li>
-<li><a href="https://www.canada.ca/fr/gouvernement/systeme.html">Comment le gouvernement fonctionne</a></li>
-<li><a href="https://ouvert.canada.ca/">Gouvernement ouvert</a></li>
-</ul>
-</nav>
-</div>
-<div class="brand">
-<div class="container">
-<div class="row">
-<nav class="col-md-9 col-lg-10 ftr-urlt-lnk">
-<h2 class="wb-inv">À propos du site</h2>
-<ul>
-<li><a href="https://www.canada.ca/fr/sociaux.html">Médias sociaux</a></li>
-<li><a href="https://www.canada.ca/fr/mobile.html">Applications mobiles</a></li>
-<li><a href="https://www1.canada.ca/fr/nouveausite.html">À propos de Canada.ca</a></li>
-<li><a href="https://www.canada.ca/fr/transparence/avis.html">Avis</a></li>
-<li><a href="https://www.canada.ca/fr/transparence/confidentialite.html">Confidentialité</a></li>
-</ul>
-</nav>
-<div class="col-xs-6 visible-sm visible-xs tofpg">
-<a href="#wb-cont">Haut de la page <span class="glyphicon glyphicon-chevron-up"></span></a>
-</div>
-	<div class="col-xs-6 col-md-3 col-lg-2 text-right">
-	<img src="http://www.canada.ca/etc/designs/canada/wet-boew/assets/wmms-blk.svg" alt="Symbole du gouvernement du Canada">
-	</div>
-	</div>
-	</div>
-	</div>
-	</footer>
-	<!--[if gte IE 9 | !IE ]><!-->
-	<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.js"></script>
-	<script src="https://wet-boew.github.io/themes-dist/GCWeb/wet-boew/js/wet-boew.min.js"></script>
-	<!--<![endif]-->
-	<!--[if lt IE 9]>
+
+
+  <footer id="wb-info">
+    <div class="landscape">
+      <nav class="container wb-navcurr">
+        <h2 class="wb-inv">Au sujet du gouvernement</h2>
+        <ul class="list-unstyled colcount-sm-2 colcount-md-3">
+          <li><a href="https://www.canada.ca/fr/contact.html">Contactez-nous</a></li>
+          <li><a href="https://www.canada.ca/fr/gouvernement/min.html">Ministères et organismes</a></li>
+          <li><a href="https://www.canada.ca/fr/gouvernement/fonctionpublique.html">Fonction publique et force militaire</a></li>
+          <li><a href="https://www.canada.ca/fr/nouvelles.html">Nouvelles</a></li>
+          <li><a href="https://www.canada.ca/fr/gouvernement/systeme/lois.html">Traités, lois et règlements</a></li>
+          <li><a href="https://www.canada.ca/fr/transparence/rapports.html">Rapports à l'échelle du gouvernement</a></li>
+          <li><a href="https://pm.gc.ca/fra">Premier ministre</a></li>
+          <li><a href="https://www.canada.ca/fr/gouvernement/systeme.html">Comment le gouvernement fonctionne</a></li>
+          <li><a href="https://ouvert.canada.ca/">Gouvernement ouvert</a></li>
+        </ul>
+      </nav>
+    </div>
+    <div class="brand">
+      <div class="container">
+        <div class="row">
+          <nav class="col-md-9 col-lg-10 ftr-urlt-lnk">
+            <h2 class="wb-inv">À propos du site</h2>
+            <ul>
+              <li><a href="https://www.canada.ca/fr/sociaux.html">Médias sociaux</a></li>
+              <li><a href="https://www.canada.ca/fr/mobile.html">Applications mobiles</a></li>
+              <li><a href="https://www1.canada.ca/fr/nouveausite.html">À propos de Canada.ca</a></li>
+              <li><a href="https://www.canada.ca/fr/transparence/avis.html">Avis</a></li>
+              <li><a href="https://www.canada.ca/fr/transparence/confidentialite.html">Confidentialité</a></li>
+            </ul>
+          </nav>
+          <div class="col-xs-6 visible-sm visible-xs tofpg">
+            <a href="#wb-cont">Haut de la page <span class="glyphicon glyphicon-chevron-up"></span></a>
+          </div>
+          <div class="col-xs-6 col-md-3 col-lg-2 text-right">
+            <img src="http://www.canada.ca/etc/designs/canada/wet-boew/assets/wmms-blk.svg" alt="Symbole du gouvernement du Canada">
+          </div>
+        </div>
+      </div>
+    </div>
+  </footer>
+  <!--[if gte IE 9 | !IE ]><!-->
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.js"></script>
+  <script src="https://wet-boew.github.io/themes-dist/GCWeb/wet-boew/js/wet-boew.min.js"></script>
+  <!--<![endif]-->
+  <!--[if lt IE 9]>
 			<script src="./wet-boew/js/ie8-wet-boew2.min.js"></script>
 
 			<![endif]-->
-	<script src="https://www.canada.ca/etc/designs/canada/wet-boew/js/theme.min.js"></script>
-	<script>
-	document.getElementById('submissionPage').value = location.href;
-</script>
+  <script src="https://www.canada.ca/etc/designs/canada/wet-boew/js/theme.min.js"></script>
+  <script>
+    document.getElementById('submissionPage').value = location.href;
+  </script>
 </body>
-	</html>
+
+</html>

--- a/mise-en-page/transparence_ng.html
+++ b/mise-en-page/transparence_ng.html
@@ -3,6 +3,7 @@
 <!--[if gt IE 8]><!-->
 <html class="no-js" lang="fr" dir="ltr">
 <!--<![endif]-->
+
 <head>
   <meta charset="utf-8">
   <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
@@ -28,10 +29,10 @@
     <link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/wet-boew/css/noscript.min.css" /></noscript>
   <script>
     (function (i, s, o, g, r, a, m) {
-    i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
-      (i[r].q = i[r].q || []).push(arguments)
-    }, i[r].l = 1 * new Date(); a = s.createElement(o),
-      m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
+      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
+        (i[r].q = i[r].q || []).push(arguments)
+      }, i[r].l = 1 * new Date(); a = s.createElement(o),
+        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
     })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
     ga('create', 'UA-105628416-1', 'auto');
     ga('send', 'pageview');
@@ -45,6 +46,7 @@
     gtag('config', 'UA-105628416-3');
   </script>
 </head>
+
 <body vocab="http://schema.org/" typeof="WebPage">
   <ul id="wb-tphp">
     <li class="wb-slc">
@@ -306,4 +308,5 @@
     document.getElementById('submissionPage').value = location.href;
   </script>
 </body>
+
 </html>

--- a/modeles-obligatoire/pages-profil-institutionnel-2.html
+++ b/modeles-obligatoire/pages-profil-institutionnel-2.html
@@ -1,297 +1,309 @@
-
-<!DOCTYPE html><!--[if lt IE 9]><html class="no-js lt-ie9" lang="en" dir="ltr"><![endif]--><!--[if gt IE 8]><!-->
+<!DOCTYPE html>
+<!--[if lt IE 9]><html class="no-js lt-ie9" lang="en" dir="ltr"><![endif]-->
+<!--[if gt IE 8]><!-->
 <html class="no-js" lang="fr" dir="ltr">
 <!--<![endif]-->
+
 <head>
-<meta charset="utf-8">
-<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+	<meta charset="utf-8">
+	<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
 		wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
-		<title>Pages d'accueil institutionnelle - Modèle obligatoire de Canada.ca - Canada.ca</title>
+	<title>Pages d'accueil institutionnelle - Modèle obligatoire de Canada.ca - Canada.ca</title>
 
-		<meta content="width=device-width,initial-scale=1" name="viewport">
+	<meta content="width=device-width,initial-scale=1" name="viewport">
 
-		<!--[if gte IE 9 | !IE ]><!-->
-<link href="https://www.canada.ca/etc/designs/canada/wet-boew/assets/favicon.ico" rel="icon" type="image/x-icon">
-<link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/css/theme.min.css"><link rel="stylesheet" href="../css/custom.css">
-<!--<![endif]-->
-<!--[if lt IE 9]>
+	<!--[if gte IE 9 | !IE ]><!-->
+	<link href="https://www.canada.ca/etc/designs/canada/wet-boew/assets/favicon.ico" rel="icon" type="image/x-icon">
+	<link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/css/theme.min.css">
+	<link rel="stylesheet" href="../css/custom.css">
+	<!--<![endif]-->
+	<!--[if lt IE 9]>
 		<link href="./GCWeb/assets/favicon.ico" rel="shortcut icon" />
 
 		<link rel="stylesheet" href="http://wet-boew.github.io/themes-dist/GCWeb/GCWeb/css/ie8-theme.min.css" />
 		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
 		<script src="./wet-boew/js/ie8-wet-boew.min.js"></script>
 		<![endif]-->
-<!--[if lte IE 9]>
+	<!--[if lte IE 9]>
 
 
 		<![endif]-->
-<noscript><link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/wet-boew/css/noscript.min.css" /></noscript>
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	<noscript>
+		<link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/wet-boew/css/noscript.min.css" /></noscript>
+	<script>
+		(function (i, s, o, g, r, a, m) {
+		i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
+			(i[r].q = i[r].q || []).push(arguments)
+		}, i[r].l = 1 * new Date(); a = s.createElement(o),
+			m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
+		})(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
 
-  ga('create', 'UA-105628416-1', 'auto');
-  ga('send', 'pageview');
+		ga('create', 'UA-105628416-1', 'auto');
+		ga('send', 'pageview');
 
-</script>
+	</script>
 
-<!-- Global site tag (gtag.js) - Google Analytics -->
+	<!-- Global site tag (gtag.js) - Google Analytics -->
 
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-105628416-3"></script>
+	<script async src="https://www.googletagmanager.com/gtag/js?id=UA-105628416-3"></script>
 
-<script>
+	<script>
 
-  window.dataLayer = window.dataLayer || [];
+		window.dataLayer = window.dataLayer || [];
 
-  function gtag(){dataLayer.push(arguments);}
+		function gtag() { dataLayer.push(arguments); }
 
-  gtag('js', new Date());
+		gtag('js', new Date());
 
 
 
-  gtag('config', 'UA-105628416-3');
+		gtag('config', 'UA-105628416-3');
 
-</script>
+	</script>
 </head>
+
 <body class="cnt-wdth-lmtd" vocab="http://schema.org/" typeof="WebPage">
-<ul id="wb-tphp">
-<li class="wb-slc">
-	<a class="wb-sl" href="#wb-cont">Passer au contenu principal</a>
-</li>
-<li class="wb-slc">
-	<a class="wb-sl" href="#wb-info">Passer à «&#160;Au sujet du gouvernement&#160;»</a>
-</li>
-</ul>
-<header>
-<div id="wb-bnr" class="container">
-<section id="wb-lng" class="text-right">
-<h2 class="wb-inv">Sélection de la langue</h2>
-<div class="row">
-<div class="col-md-12">
-<ul class="list-inline margin-bottom-none">
-	<li><a lang="en" href="https://design.canada.ca/mandatory-templates/institutional-profile-pages.html">English</a></li>
-</ul>
-</div>
-</div>
-</section>
-<div class="row">
-<div class="brand col-xs-5 col-md-4">
-<a href="https://www.canada.ca/fr.html"><img src="http://www.canada.ca/etc/designs/canada/wet-boew/assets/sig-blk-fr.svg" alt=""><span class="wb-inv"> Gouvernement du Canada / <span lang="en">Government of Canada</span></span></a>
-</div>
-<section id="wb-srch" class="col-lg-8 text-right">
-	<h2>Recherche</h2>
-<form action="https://recherche-search.gc.ca/rGs/s_r?#wb-land" method="get" role="search" class="form-inline">
+	<ul id="wb-tphp">
+		<li class="wb-slc">
+			<a class="wb-sl" href="#wb-cont">Passer au contenu principal</a>
+		</li>
+		<li class="wb-slc">
+			<a class="wb-sl" href="#wb-info">Passer à «&#160;Au sujet du gouvernement&#160;»</a>
+		</li>
+	</ul>
+	<header>
+		<div id="wb-bnr" class="container">
+			<section id="wb-lng" class="text-right">
+				<h2 class="wb-inv">Sélection de la langue</h2>
+				<div class="row">
+					<div class="col-md-12">
+						<ul class="list-inline margin-bottom-none">
+							<li><a lang="en" href="https://design.canada.ca/mandatory-templates/institutional-profile-pages.html">English</a></li>
+						</ul>
+					</div>
+				</div>
+			</section>
+			<div class="row">
+				<div class="brand col-xs-5 col-md-4">
+					<a href="https://www.canada.ca/fr.html"><img src="http://www.canada.ca/etc/designs/canada/wet-boew/assets/sig-blk-fr.svg" alt=""><span class="wb-inv"> Gouvernement du Canada / <span lang="en">Government of Canada</span></span></a>
+				</div>
+				<section id="wb-srch" class="col-lg-8 text-right">
+					<h2>Recherche</h2>
+					<form action="https://recherche-search.gc.ca/rGs/s_r?#wb-land" method="get" role="search" class="form-inline">
 
-<div class="form-group">
+						<div class="form-group">
 
-	<label for="wb-srch-q" class="wb-inv">Rechercher dans Canada.ca</label>
+							<label for="wb-srch-q" class="wb-inv">Rechercher dans Canada.ca</label>
 
-	<input id="wb-srch-q" list="wb-srch-q-ac" class="wb-srch-q form-control" name="q" type="search" value="" size="34" maxlength="170" placeholder="Rechercher dans Canada.ca">
+							<input id="wb-srch-q" list="wb-srch-q-ac" class="wb-srch-q form-control" name="q" type="search" value="" size="34" maxlength="170" placeholder="Rechercher dans Canada.ca">
 
-<input name="st" value="s" type="hidden"/>
+							<input name="st" value="s" type="hidden" />
 
-<input name="num" value="10" type="hidden"/>
+							<input name="num" value="10" type="hidden" />
 
-<input name="langs" value="fra" type="hidden"/>
+							<input name="langs" value="fra" type="hidden" />
 
-<input name="st1rt" value="0" type="hidden">
+							<input name="st1rt" value="0" type="hidden">
 
-<input name="s5bm3ts21rch" value="x" type="hidden"/>
+							<input name="s5bm3ts21rch" value="x" type="hidden" />
 
-<datalist id="wb-srch-q-ac">
+							<datalist id="wb-srch-q-ac">
 
-<!--[if lte IE 9]><select><![endif]-->
+								<!--[if lte IE 9]><select><![endif]-->
 
-<!--[if lte IE 9]></select><![endif]-->
+								<!--[if lte IE 9]></select><![endif]-->
 
-</datalist>
+							</datalist>
 
-</div>
+						</div>
 
-<div class="form-group submit">
+						<div class="form-group submit">
 
-	<button type="submit" id="wb-srch-sub" class="btn btn-primary btn-small" name="wb-srch-sub"><span class="glyphicon-search glyphicon"></span><span class="wb-inv">Recherche</span></button>
-
-
-</div>
-
-</form>
+							<button type="submit" id="wb-srch-sub" class="btn btn-primary btn-small" name="wb-srch-sub"><span class="glyphicon-search glyphicon"></span><span class="wb-inv">Recherche</span></button>
 
 
-</section>
-</div>
-</div>
-<nav class="gweb-v2 gcweb-menu" typeof="SiteNavigationElement">
-<div class="container">
-<h2 class="wb-inv">Menu</h2>
-<button type="button" aria-haspopup="true" aria-controls="gc-mnu" aria-expanded="false">Menu<span class="wb-inv"> principal</span> <span class="expicon glyphicon glyphicon-chevron-down"></span></button>
-<ul id="gc-mnu" role="menu" aria-orientation="vertical" data-ajax-replace="https://www.canada.ca/content/dam/canada/sitemenu/sitemenu-v2-fr.html">
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/jobs.html">Emplois et milieu de travail</a></li>
+						</div>
 
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/immigration-citizenship.html">Immigration et citoyenneté</a></li>
-
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://voyage.gc.ca/">Voyage et tourisme</a></li>
-
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/entreprises.html">Entreprises et industrie</a></li>
-
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/benefits.html">Prestations</a></li>
-
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/sante.html">Santé</a></li>
-
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/impots.html">Impôts</a></li>
-
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/environnement.html">Environnement et ressources naturelles</a></li>
-
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/defense.html">Sécurité nationale et défense</a></li>
-
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/culture.html">Culture, histoire et sport</a></li>
-
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/police.html">Services de police, justice et urgences</a></li>
-
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/transport.html">Transport et infrastructure</a></li>
-
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="http://international.gc.ca/world-monde/index.aspx?lang=fra">Canada et le monde</a></li>
-
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/finance.html">Argent et finances</a></li>
-
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/science.html">Science et innovation</a></li>
-
-</ul>
-</div>
-</nav>
-<nav id="wb-bc" property="breadcrumb">
-<h2>Vous êtes ici :</h2>
-<div class="container">
-<ol class="breadcrumb">
-	<li><a href='https://www.canada.ca/fr.html'>Accueil</a></li>
-	<li><a href='https://www.canada.ca/fr/gouvernement/a-propos.html'>À propos de Canada.ca</a></li>
-<li><a href='https://www.canada.ca/fr/gouvernement/a-propos/systeme-conception.html'>Système de conception de Canada.ca</a></li>
-	<li><a href='https://www.canada.ca/fr/gouvernement/a-propos/systeme-conception/bibliotheque-modeles.html'>Bibliothèque de modèles et de configurations de conception</a></li>
-</ol>
-</div>
-</nav>
-</header>
+					</form>
 
 
-</div>
+				</section>
+			</div>
+		</div>
+		<nav class="gweb-v2 gcweb-menu" typeof="SiteNavigationElement">
+			<div class="container">
+				<h2 class="wb-inv">Menu</h2>
+				<button type="button" aria-haspopup="true" aria-controls="gc-mnu" aria-expanded="false">Menu<span class="wb-inv"> principal</span> <span class="expicon glyphicon glyphicon-chevron-down"></span></button>
+				<ul id="gc-mnu" role="menu" aria-orientation="vertical" data-ajax-replace="https://www.canada.ca/content/dam/canada/sitemenu/sitemenu-v2-fr.html">
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/jobs.html">Emplois et milieu de travail</a></li>
+
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/immigration-citizenship.html">Immigration et citoyenneté</a></li>
+
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://voyage.gc.ca/">Voyage et tourisme</a></li>
+
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/entreprises.html">Entreprises et industrie</a></li>
+
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/benefits.html">Prestations</a></li>
+
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/sante.html">Santé</a></li>
+
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/impots.html">Impôts</a></li>
+
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/environnement.html">Environnement et ressources naturelles</a></li>
+
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/defense.html">Sécurité nationale et défense</a></li>
+
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/culture.html">Culture, histoire et sport</a></li>
+
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/police.html">Services de police, justice et urgences</a></li>
+
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/transport.html">Transport et infrastructure</a></li>
+
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="http://international.gc.ca/world-monde/index.aspx?lang=fra">Canada et le monde</a></li>
+
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/finance.html">Argent et finances</a></li>
+
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/science.html">Science et innovation</a></li>
+
+				</ul>
+			</div>
+		</nav>
+		<nav id="wb-bc" property="breadcrumb">
+			<h2>Vous êtes ici :</h2>
+			<div class="container">
+				<ol class="breadcrumb">
+					<li><a href='https://www.canada.ca/fr.html'>Accueil</a></li>
+					<li><a href='https://www.canada.ca/fr/gouvernement/a-propos.html'>À propos de Canada.ca</a></li>
+					<li><a href='https://www.canada.ca/fr/gouvernement/a-propos/systeme-conception.html'>Système de conception de Canada.ca</a></li>
+					<li><a href='https://www.canada.ca/fr/gouvernement/a-propos/systeme-conception/bibliotheque-modeles.html'>Bibliothèque de modèles et de configurations de conception</a></li>
+				</ol>
+			</div>
+		</nav>
+	</header>
 
 
-
-</div>
+	</div>
 
 
 
-<style> /* to move later */
+	</div>
 
-/* added to detail summaries inside the code to remove the bottom spacing */
-.pattern-demo-code-ex details {
-	margin-bottom: 0px !important;
-}
 
-.pattern-demo-code-ex .featured {
-	margin-left: .07em !important;
-	margin-right: .07em !important;
-}
 
-/* .pattern-demo-code-ex .gc-prtts {
+	<style>
+		/* to move later */
+
+		/* added to detail summaries inside the code to remove the bottom spacing */
+		.pattern-demo-code-ex details {
+			margin-bottom: 0px !important;
+		}
+
+		.pattern-demo-code-ex .featured {
+			margin-left: .07em !important;
+			margin-right: .07em !important;
+		}
+
+		/* .pattern-demo-code-ex .gc-prtts {
 	width: 99%;
 } */
 
-.pattern-demo {
-	padding: 0px !important;
-	margin: 0px !important;
-	border: none !important;
-}
+		.pattern-demo {
+			padding: 0px !important;
+			margin: 0px !important;
+			border: none !important;
+		}
 
-.pattern-demo-code-ex {
-	margin-left: -35px !important;
-	margin-right: -35px !important;
-}
+		.pattern-demo-code-ex {
+			margin-left: -35px !important;
+			margin-right: -35px !important;
+		}
 
-.guidance-details details, .guidance-details summary, .guidance-details details summary:focus, .guidance-details details summary:hover {
-	background-color: white;
-}
-@media (min-width: 1200px) {
-	.pattern-demo-ex .container {
-	   width: 1100px;
-	}
-}
+		.guidance-details details,
+		.guidance-details summary,
+		.guidance-details details summary:focus,
+		.guidance-details details summary:hover {
+			background-color: white;
+		}
 
-</style>
-
-
-
-
-
+		@media (min-width: 1200px) {
+			.pattern-demo-ex .container {
+				width: 1100px;
+			}
+		}
+	</style>
 
 
 
 
 
-<!--/* Hide Nav; Hide Right Rail /*-->
-
-
-<main role="main" property="mainContentOfPage" class="container wb-prettify all-pre">
-
-
-<h1 property="name" id="wb-cont" dir="ltr">
-Pages d'accueil institutionnelle - Modèle obligatoire de Canada.ca</h1>
 
 
 
 
-		<div><div class="mwsgeneric-base-html parbase section">
+
+	<!--/* Hide Nav; Hide Right Rail /*-->
+
+
+	<main role="main" property="mainContentOfPage" class="container wb-prettify all-pre">
+
+
+		<h1 property="name" id="wb-cont" dir="ltr">
+			Pages d'accueil institutionnelle - Modèle obligatoire de Canada.ca</h1>
 
 
 
-<p class="gc-byline"><strong>De : <a href="https://www.canada.ca/fr/secretariat-conseil-tresor.html">Secrétariat du Conseil du Trésor du Canada</a></strong></p>
+
+		<div>
+			<div class="mwsgeneric-base-html parbase section">
 
 
-	<section>
-				<p><span class="label label-danger">Obligatoire</span></p>
-				<p>Utilisez ce modèle comme page d'accueil pour les institutions et organismes du gouvernement du Canada.</p>
-				<p>Le but de cette page est de permettre aux gens de trouver les renseignements et les services offerts par cette institution, en se concentrant sur les tâches les plus importantes.</p>
-				<p>Il devrait également permettre aux gens de trouver tous les autres contenus appartenant à cette institution, y compris :</p>
-				<ul>
-					<li>le mandat et la structure organisationnelle</li>
-					<li>les coordonnées</li>
-					<li>les nouvelles et les promotions</li>
-					<li>les rapports et les publications</li>
-				</ul>
-			</section>
 
-			<section>
-				<h2>Sur cette page</h2>
-				<ul>
-					<li><a href="#utiliser">Quand l'utiliser</a></li>
-					<li><a href="#eviter">Quoi éviter</a></li>
-					<li><a href="#comment">Comment mettre en œuvre</a></li>
-					<li><a href="#recherche">Recherche</a></li>
-					<li><a href="#changements">Derniers changements</a></li>
-					<li><a href="#discussion">Discussion</a></li>
-				</ul>
-			</section>
+				<p class="gc-byline"><strong>De : <a href="https://www.canada.ca/fr/secretariat-conseil-tresor.html">Secrétariat du Conseil du Trésor du Canada</a></strong></p>
 
-			<section>
-				<h2 id="utiliser">Quand l'utiliser</h2>
-				<p>Toutes les institutions et les organismes du gouvernement du Canada assujetties à la <a href="https://www.tbs-sct.gc.ca/pol/doc-fra.aspx?id=30682"><cite>Directive sur la gestion des communications</cite></a>  doivent utiliser ce modèle comme page d'accueil unique.</p>
-				<p>Consultez la <a href="https://www.canada.ca/fr/gouvernement/a-propos/systeme-conception/liste-institutions.html">liste d'institutions de Canada.ca</a> pour la liste complète.</p>
-			</section>
 
-			<section>
-				<h2 id="eviter">Quoi éviter</h2>
-				<p>N'utilisez ce modèle que comme page d'accueil des institutions et organismes officiels de la <a href="https://www.canada.ca/fr/gouvernement/a-propos/systeme-conception/liste-institutions.html">liste d'institutions de Canada.ca</a>.</p>
-				<p>N'utilisez pas ce modèle pour des programmes ou entités spécifiques qui ne sont pas des institutions ou organismes officiels du gouvernement du Canada.</p>
-			</section>
+				<section>
+					<p><span class="label label-danger">Obligatoire</span></p>
+					<p>Utilisez ce modèle comme page d'accueil pour les institutions et organismes du gouvernement du Canada.</p>
+					<p>Le but de cette page est de permettre aux gens de trouver les renseignements et les services offerts par cette institution, en se concentrant sur les tâches les plus importantes.</p>
+					<p>Il devrait également permettre aux gens de trouver tous les autres contenus appartenant à cette institution, y compris :</p>
+					<ul>
+						<li>le mandat et la structure organisationnelle</li>
+						<li>les coordonnées</li>
+						<li>les nouvelles et les promotions</li>
+						<li>les rapports et les publications</li>
+					</ul>
+				</section>
 
-			<section>
-				<h2 id="comment">Comment mettre en œuvre</h2>
-			</section>
+				<section>
+					<h2>Sur cette page</h2>
+					<ul>
+						<li><a href="#utiliser">Quand l'utiliser</a></li>
+						<li><a href="#eviter">Quoi éviter</a></li>
+						<li><a href="#comment">Comment mettre en œuvre</a></li>
+						<li><a href="#recherche">Recherche</a></li>
+						<li><a href="#changements">Derniers changements</a></li>
+						<li><a href="#discussion">Discussion</a></li>
+					</ul>
+				</section>
 
-			<section>
-				<p>Vous pouvez utiliser la version <strong>bêta</strong> ou la version <strong>stable</strong> de ce modèle.</p>
+				<section>
+					<h2 id="utiliser">Quand l'utiliser</h2>
+					<p>Toutes les institutions et les organismes du gouvernement du Canada assujetties à la <a href="https://www.tbs-sct.gc.ca/pol/doc-fra.aspx?id=30682"><cite>Directive sur la gestion des communications</cite></a> doivent utiliser ce modèle comme page d'accueil unique.</p>
+					<p>Consultez la <a href="https://www.canada.ca/fr/gouvernement/a-propos/systeme-conception/liste-institutions.html">liste d'institutions de Canada.ca</a> pour la liste complète.</p>
+				</section>
+
+				<section>
+					<h2 id="eviter">Quoi éviter</h2>
+					<p>N'utilisez ce modèle que comme page d'accueil des institutions et organismes officiels de la <a href="https://www.canada.ca/fr/gouvernement/a-propos/systeme-conception/liste-institutions.html">liste d'institutions de Canada.ca</a>.</p>
+					<p>N'utilisez pas ce modèle pour des programmes ou entités spécifiques qui ne sont pas des institutions ou organismes officiels du gouvernement du Canada.</p>
+				</section>
+
+				<section>
+					<h2 id="comment">Comment mettre en œuvre</h2>
+				</section>
+
+				<section>
+					<p>Vous pouvez utiliser la version <strong>bêta</strong> ou la version <strong>stable</strong> de ce modèle.</p>
 
 					<h3>Version bêta de la page d'accueil institutionnelle</h3>
 					<p>La version bêta est une amélioration par rapport à la version stable. Elle pourrait faire l'objet de changements mineurs.</p>
@@ -300,35 +312,35 @@ Pages d'accueil institutionnelle - Modèle obligatoire de Canada.ca</h1>
 
 					<div class="row mrgn-tp-lg mrgn-bttm-lg">
 						<div class="col-xs-10 col-sm-10 col-md-8 col-lg-8">
-								<div class="gc-dwnld">
-									<div class="row">
-										<div class="col-xs-10 col-sm-3 col-md-3 col-lg-2">
-											<p><a class="gc-dwnld-lnk" href="../mise-en-page/accueil-institution-directives.html"><img class="thumbnail gc-dwnld-img" src="../images/ip-img-fr-cropped.png" alt="" width="110" height="142"></a></p>
-										</div>
-										<div class="col-xs-12 col-sm-9 col-md-9 col-lg-10">
-											<p style="font-size:24px;line-height:1em;" class="mrgn-tp-md"><span>Version bêta de la page d'accueil institutionnelle</span></p>
-											<p><a class="btn btn-call-to-action" href="../mise-en-page/accueil-institution-directives.html">Modèle avec directives</a></p>
-											<!-- <p class="mrgn-tp-md" style="line-height:3em;"><a class="btn btn-primary mrgn-rght-sm" href="citizenship-test/study-guide.html" role="button">Start studying</a></p> -->
-											<!--<p class="mrgn-tp-lg">or <a class="gc-dwnld-lnk" href="citizenship-test/study-guide.html">download the PDF version</a></p>-->
-										</div>
-									</div><!-- .row -->
-								</div><!-- .well gc-dwnld -->
+							<div class="gc-dwnld">
+								<div class="row">
+									<div class="col-xs-10 col-sm-3 col-md-3 col-lg-2">
+										<p><a class="gc-dwnld-lnk" href="../mise-en-page/accueil-institution-directives.html"><img class="thumbnail gc-dwnld-img" src="../images/ip-img-fr-cropped.png" alt="" width="110" height="142"></a></p>
+									</div>
+									<div class="col-xs-12 col-sm-9 col-md-9 col-lg-10">
+										<p style="font-size:24px;line-height:1em;" class="mrgn-tp-md"><span>Version bêta de la page d'accueil institutionnelle</span></p>
+										<p><a class="btn btn-call-to-action" href="../mise-en-page/accueil-institution-directives.html">Modèle avec directives</a></p>
+										<!-- <p class="mrgn-tp-md" style="line-height:3em;"><a class="btn btn-primary mrgn-rght-sm" href="citizenship-test/study-guide.html" role="button">Start studying</a></p> -->
+										<!--<p class="mrgn-tp-lg">or <a class="gc-dwnld-lnk" href="citizenship-test/study-guide.html">download the PDF version</a></p>-->
+									</div>
+								</div><!-- .row -->
+							</div><!-- .well gc-dwnld -->
 						</div><!-- .col-sm-8 -->
 					</div>
 
 
-						<!-- <p><a class="btn btn-call-to-action" href="../mise-en-page/accueil-institution-directives.html">Modèle avec directives</a></p> -->
+					<!-- <p><a class="btn btn-call-to-action" href="../mise-en-page/accueil-institution-directives.html">Modèle avec directives</a></p> -->
 
-						<!-- </div> <!-- end col-lg-12 -->
-						<!-- <div class="clearfix"></div> -->
-						<!-- <div class="col-lg-12"> -->
-						<details>
-							<summary>Code</summary>
-							<div class="wb-tabs">
-								<div class="tabpanels">
-									<details id="details-panel1">
-										<summary>HTML</summary>
-										<pre><code>&#x3C;div class=&#x22;ip-cover-img&#x22;&#x3E;
+					<!-- </div> <!-- end col-lg-12 -->
+					<!-- <div class="clearfix"></div> -->
+					<!-- <div class="col-lg-12"> -->
+					<details>
+						<summary>Code</summary>
+						<div class="wb-tabs">
+							<div class="tabpanels">
+								<details id="details-panel1">
+									<summary>HTML</summary>
+									<pre><code>&#x3C;div class=&#x22;ip-cover-img&#x22;&#x3E;
  &#x3C;div class=&#x22;container&#x22;&#x3E;
   &#x3C;div class=&#x22;col-lg-7 col-md-7 row&#x22;&#x3E;
    &#x3C;h1 property=&#x22;name&#x22; id=&#x22;wb-cont&#x22;&#x3E;[Nom de l&#x27;institution]&#x3C;/h1&#x3E;
@@ -584,10 +596,10 @@ Pages d'accueil institutionnelle - Modèle obligatoire de Canada.ca</h1>
    &#x3C;/div&#x3E;
  &#x3C;/section&#x3E;
 &#x3C;/div&#x3E;</code></pre>
-									</details>
-									<details id="details-panel2">
-										<summary>CSS</summary>
-										<pre><code>.ip-cover-img {
+								</details>
+								<details id="details-panel2">
+									<summary>CSS</summary>
+									<pre><code>.ip-cover-img {
 	&#x9;background-image: url(&#x22;https://test.canada.ca/experimental/working-on/images/ip-cover-image.jpg&#x22;);
 	&#x9;background-repeat: no-repeat;
 	&#x9;background-size: cover;
@@ -693,670 +705,679 @@ Pages d'accueil institutionnelle - Modèle obligatoire de Canada.ca</h1>
 	}
 
 	}</code></pre>
-									</details>
-								</div>
+								</details>
 							</div>
-						</details>
-						<!-- </div> -->
+						</div>
+					</details>
+					<!-- </div> -->
 
 
-				<div class="clearfix"></div>
+					<div class="clearfix"></div>
 
-	<h3>Version stable de la page d'accueil institutionnelle</h3>
-	<p>La version stable sera éventuellement remplacée par la version bêta.</p>
-	<details>
-		<summary>Directives pour la version stable de la page d'accueil institutionnelle</summary>
-<h3 id="profil">Page de profil</h3>
-<p>Toutes les institutions mentionnées aux annexes I, I.1 et II de la <a href="http://laws-lois.justice.gc.ca/fra/lois/f-11/">Loi sur la gestion des finances publiques</a>&nbsp;(LGFP) doivent élaborer un profil institutionnel. Tous ces profils font partie de la page des ministères et organismes (voir la section sur la <a href="./page-ministeres-organismes.html">page des ministères et organismes</a>).</p>
-<div class="btn-group mrgn-bttm-sm">
-	<button type="button" class="btn btn-default wb-toggle" data-toggle="{&quot;selector&quot;: &quot;details&quot;, &quot;parent&quot;: &quot;#template-elements&quot;, &quot;type&quot;: &quot;on&quot;}">Développer tout</button>
-	<button type="button" class="btn btn-default wb-toggle" data-toggle="{&quot;selector&quot;: &quot;details&quot;, &quot;parent&quot;: &quot;#template-elements&quot;, &quot;type&quot;: &quot;off&quot;}">Réduire tout</button>
-</div>
-<div class="row">
-	<div class="col-lg-6 pull-right">
-		<figure class="mrgn-bttm-lg">
-			<figcaption class="text-center"><b>Modèle de la page de profil institutionnel</b></figcaption>
-			<img src="https://www.canada.ca/content/dam/tbs-sct/images/government-communications/canada-content-style-guide/institutional-profile-fra-02.jpg" class="full-width" alt="Modèle de la page de profil institutionnel pour les grandes institutions indiquant les parties qui composent sa structure. Lire de haut en bas et de gauche à droite. Plus de détails au sujet de ce graphique se retrouvent dans le texte entourant l’image."> </figure>
-	</div>
-	<div class="col-lg-6 pull-left">
-		<section id="template-elements">
-			<section>
-				<h4>1&nbsp;: Nom de l’institution</h4>
-				<p><span class="label label-danger">Obligatoire</span></p>
-				<p>Fournit le titre d’usage de l’institution</p>
-				<ul class="list-unstyled">
-					<li id="element1">
-						<details class="mrgn-bttm-sm">
-							<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Contenu</strong></summary>
-							<ul>
-								<li>Utilisez le titre d’usage de l’institution indiqué dans le <a href="https://www.tbs-sct.gc.ca/hgw-cgf/oversight-surveillance/communications/fip-pcim/reg-fra.asp">Registre des titres d’usage</a>.</li>
-								<li>Utilisez le titre légal si le titre d’usage n’est pas disponible.</li>
-								<li>N’utilisez pas d’acronymes ou d’abréviations.</li>
-							</ul>
-						</details>
-					</li>
-					<li id="element2">
-						<details class="mrgn-bttm-sm">
-							<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Présentation</strong></summary>
-							<ul>
-								<li>Le titre du profil institutionnel doit être une balise H1 unique.</li>
-								<li>Il doit être la première composante de la page.</li>
-							</ul>
-						</details>
-					</li>
-				</ul>
-			</section>
-			<section>
-				<h4>2a&nbsp;: Insigne</h4>
-				<p><span class="label label-warning">Conditionelle</span></p>
-				<p>Fournit l’identification de la Gendarmerie royale du Canada</p>
-				<ul class="list-unstyled">
-					<li id="element3">
-						<details class="mrgn-bttm-sm">
-							<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Contenu</strong></summary>
-							<ul>
-								<li>Seule la Gendarmerie royale du Canada peut utiliser cette composante pour afficher son insigne approuvé.</li>
-							</ul>
-						</details>
-					</li>
-					<li id="element4">
-						<details class="mrgn-bttm-sm">
-							<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Présentation</strong></summary>
-							<ul>
-								<li>L’insigne se trouve à la droite du mandat de l’institution.</li>
-								<li>L’image n’est pas assortie d’un hyperlien.</li>
-							</ul>
-						</details>
-					</li>
-				</ul>
-			</section>
-			<section>
-				<h4>3&nbsp;: Mandat de l’institution</h4>
-				<p><span class="label label-danger">Obligatoire</span></p>
-				<p>Décrit en une ou deux phrases le mandat de l’institution</p>
-				<ul class="list-unstyled">
-					<li id="element5">
-						<details class="mrgn-bttm-sm">
-							<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Contenu</strong></summary>
-							<ul>
-								<li>Elle fournit le titre d’usage de l’institution suivi d’un aperçu en langage clair de la façon dont l’institution assure des services au public.</li>
-								<li>Le texte doit être court et concis.</li>
-								<li>Le contenu est rédigé pour un niveau de scolarité secondaire (pointage de 100 et moins dans <a href="http://www.scolarius.com/">Scolarius</a>).</li>
-							</ul>
-						</details>
-					</li>
-					<li id="element6">
-						<details class="mrgn-bttm-sm">
-							<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Présentation</strong></summary>
-							<ul>
-								<li>Le mandat de l’institution figure juste au-dessous du titre de la page du profil institutionnel.</li>
-							</ul>
-						</details>
-					</li>
-				</ul>
-			</section>
-			<section>
-				<h4>4&nbsp;: Réseaux de médias sociaux de l’institution</h4>
-				<p><span class="label label-warning">Conditionelle</span></p>
-				<p>Présente les réseaux de médias sociaux propres à l’institution</p>
-				<ul class="list-unstyled">
-					<li id="element7">
-						<details class="mrgn-bttm-sm">
-							<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Contenu</strong></summary>
-							<ul>
-								<li>Cette composante est obligatoire pour toutes les institutions mentionnées à l’<a href="http://laws-lois.justice.gc.ca/fra/lois/F-11/page-30.html#h-74">annexe I de la LGFP</a>, et facultative pour les autres institutions.</li>
-								<li>Utilisez la configuration <a href="../configurations-conception-communes/bloc-medias-sociaux.html">Bloc des réseaux de médias sociaux (fenêtre «&nbsp;Suivez&nbsp;»)</a>.</li>
-							</ul>
-						</details>
-					</li>
-					<li id="element8">
-						<details class="mrgn-bttm-sm">
-							<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Présentation</strong></summary>
-							<ul>
-								<li>Cette composante se trouve sous le mandat de l’institution.</li>
-							</ul>
-						</details>
-					</li>
-				</ul>
-			</section>
-			<section>
-				<h4>5&nbsp;: Nouveautés</h4>
-				<p><span class="label label-warning">Conditionelle</span></p>
-				<p>Présente les nouvelles ayant trait à l’institution</p>
-				<ul class="list-unstyled">
-					<li id="element9">
-						<details class="mrgn-bttm-sm">
-							<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Contenu</strong></summary>
-							<ul>
-								<li>Cette composante est obligatoire pour toutes les institutions mentionnées à l’<a href="http://laws-lois.justice.gc.ca/fra/lois/F-11/page-30.html#h-74">annexe I de la LGFP</a>, et facultative pour les autres institutions.</li>
-								<li>Utilisez la configuration <a href="../configurations-conception-communes/nouveautes.html">Nouveautés</a>.</li>
-							</ul>
-						</details>
-					</li>
-					<li id="element10">
-						<details class="mrgn-bttm-sm">
-							<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Présentation</strong></summary>
-							<ul>
-								<li>Cette composante se trouve sous «&nbsp;Réseaux de médias sociaux de l’institution&nbsp;».</li>
-							</ul>
-						</details>
-					</li>
-				</ul>
-			</section>
-			<section>
-				<h4>6&nbsp;: Services et renseignements</h4>
-				<p><span class="label label-danger">Obligatoire</span></p>
-				<p>Dresse la liste des sujets propres à l’institution</p>
-				<ul class="list-unstyled">
-					<li id="element11">
-						<details class="mrgn-bttm-sm">
-							<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Contenu</strong></summary>
-							<ul>
-								<li>Utilisez la configuration <a href="../configurations-conception-communes/services-renseignements.html">Services et renseignements</a>.</li>
-							</ul>
-						</details>
-					</li>
-					<li id="element12">
-						<details class="mrgn-bttm-sm">
-							<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Présentation</strong></summary>
-							<ul>
-								<li>Cette composante se trouve sous la section «&nbsp;Réseaux de médias sociaux&nbsp;» et à gauche de la section «&nbsp;En demande&nbsp;».</li>
-							</ul>
-						</details>
-					</li>
-				</ul>
-			</section>
-			<section>
-				<h4>7&nbsp;: En demande</h4>
-				<p><span class="label label-warning">Conditionelle</span></p>
-				<p>Présente les services et renseignements les plus demandés propres à l’institution</p>
-				<ul class="list-unstyled">
-					<li id="element13">
-						<details class="mrgn-bttm-sm">
-							<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Contenu</strong></summary>
-							<ul>
-								<li>composante  est obligatoire afin fournir des raccourcis vers les tâches les plus  importantes de l'institution. Cependant, elle ne devrait pas être utilisée si  toutes les tâches principales de l'institution sont déjà incluses en tant que  liens directs sous «&nbsp;Services et renseignements&nbsp;».</li>
-								<li>Utilisez la configuration <a href="../configurations-conception-communes/en-demande.html">En demande</a>.</li>
-							</ul>
-						</details>
-					</li>
-					<li id="element14">
-						<details class="mrgn-bttm-sm">
-							<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Présentation</strong></summary>
-							<ul>
-								<li>Cette composante figure à droite de la section «&nbsp;Services et renseignements&nbsp;».</li>
-							</ul>
-						</details>
-					</li>
-				</ul>
-			</section>
-			<section>
-				<h4>8&nbsp;: Contactez-nous</h4>
-				<p><span class="label label-danger">Obligatoire</span></p>
-				<p>Donne accès aux coordonnées de l’institution</p>
-				<ul class="list-unstyled">
-					<li id="element15">
-						<details class="mrgn-bttm-sm">
-							<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Contenu</strong></summary>
-							<ul>
-								<li>Allez à <a href="../configurations-conception-communes/coordonnees.html">Coordonnées</a> dans les Configurations de conception communes. Utilisez, selon le cas, le modèle d’adresse ou le modèle de lien.</li>
-							</ul>
-						</details>
-					</li>
-					<li id="element16">
-						<details class="mrgn-bttm-sm">
-							<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Présentation</strong></summary>
-							<ul>
-								<li>Cette composante est placée sous «&nbsp;Nouveautés&nbsp;» et à droite de «&nbsp;Services et renseignements&nbsp;».</li>
-							</ul>
-						</details>
-					</li>
-				</ul>
-			</section>
-			<section>
-				<h4>9&nbsp;: Autres renseignements pour les</h4>
-				<p><span class="label label-info">Facultative</span></p>
-				<p>Liens menant à des renseignements intéressant divers publics cibles</p>
-				<ul class="list-unstyled">
-					<li id="element17">
-						<details class="mrgn-bttm-sm">
-							<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Contenu</strong></summary>
-							<ul>
-								<li>Utilisez la configuration <a href="../configurations-conception-communes/autres-renseignements.html">Autres renseignements pour les</a>.</li>
-							</ul>
-						</details>
-					</li>
-					<li id="element18">
-						<details class="mrgn-bttm-sm">
-							<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Présentation</strong></summary>
-							<ul>
-								<li>Cette composante figure sous la section «&nbsp;En demande&nbsp;».</li>
-							</ul>
-						</details>
-					</li>
-				</ul>
-			</section>
-			<section>
-				<h4>10&nbsp;: Ce que nous faisons</h4>
-				<p><span class="label label-warning">Conditionelle</span></p>
-				<p>Fournit des liens vers le contenu relatif à l’élaboration des politiques et programmes de l’institution</p>
-				<ul class="list-unstyled">
-					<li id="element19">
-						<details class="mrgn-bttm-sm">
-							<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Contenu</strong></summary>
-							<ul>
-								<li>Cette composante est obligatoire quand  l’institution a du contenu d’élaboration de programmes et de politiques à  présenter.</li>
-								<li>Utilisez la configuration <a href="../configurations-conception-communes/ce-que-nous-faisons.html">Ce que nous faisons</a>.</li>
-							</ul>
-						</details>
-					</li>
-					<li id="element20">
-						<details class="mrgn-bttm-sm">
-							<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Présentation</strong></summary>
-							<ul>
-								<li>Cette composante figure sous la section «&nbsp;Services et renseignements&nbsp;».</li>
-							</ul>
-						</details>
-					</li>
-				</ul>
-			</section>
-			<section>
-				<h4>11&nbsp;: Renseignements organisationnels</h4>
-				<p><span class="label label-danger">Obligatoire</span></p>
-				<p>Fournit un accès uniforme aux principaux renseignements organisationnels</p>
-				<ul class="list-unstyled">
-					<li id="element21">
-						<details class="mrgn-bttm-sm">
-							<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Contenu</strong></summary>
-							<ul>
-								<li>Cette composante consiste en une série de liens menant au contenu propre à l’institution qui n’est pas présenté ailleurs sur la page.</li>
-								<li>L’étiquette de l’en-tête est «&nbsp;Renseignements organisationnels&nbsp;».</li>
-								<li>Seuls les liens «&nbsp;Mandat&nbsp;» et «&nbsp;Transparence&nbsp;» sont obligatoires; tous les autres liens sont facultatifs.</li>
-								<li>Les liens doivent être étiquetés et ordonnés de la façon suivante&nbsp;:
-									<dl class="dl-horizontal">
-										<dt><strong>Mandat</strong></dt>
-										<dd>
-											<ul>
-												<li>Obligatoire</li>
-												<li>Mène à une page présentant le mandat, la vision et les objectifs de l’institution</li>
-											</ul>
-										</dd>
-										<dt><strong>Programmes</strong></dt>
-										<dd>
-											<ul>
-												<li>Facultatif</li>
-												<li>Mène à une page fournissant la liste des programmes de l’institution</li>
-											</ul>
-										</dd>
-										<dt><strong>Structure organisationnelle</strong></dt>
-										<dd>
-											<ul>
-												<li>Facultatif</li>
-												<li>Mène à une page présentant l’organigramme ou la structure organisationnelle de l’institution</li>
-											</ul>
-										</dd>
-										<dt><strong>Portefeuille</strong></dt>
-										<dd>
-											<ul>
-												<li>Facultatif</li>
-												<li>Mène à une page présentant le portefeuille ministériel de l’institution</li>
-											</ul>
-										</dd>
-										<dt><strong>Partenaires</strong></dt>
-										<dd>
-											<ul>
-												<li>Facultatif</li>
-												<li>Mène à une page présentant les partenariats officiels de l’institution (c’est-à-dire des organisations fédérales, provinciales, territoriales, internationales ou non gouvernementales)</li>
-											</ul>
-										</dd>
-										<dt><strong>Transparence</strong></dt>
-										<dd>
-											<ul>
-												<li>Obligatoire</li>
-												<li>Mène aux renseignements sur la transparence propres à l’institution prescrits par le Secrétariat du Conseil du Trésor, comme les plans prospectifs de la réglementation et la divulgation proactive</li>
-											</ul>
-										</dd>
-										<dt><strong>Possibilités d’emploi</strong></dt>
-										<dd>
-											<ul>
-												<li>Facultatif</li>
-												<li>Mène à une page cible présentant les possibilités d’emploi au sein de l’institution</li>
-											</ul>
-										</dd>
-										<dt><strong>Compte rendu du rendement des services</strong></dt>
-										<dd>
-											<ul>
-												<li>Obligatoire, si le contenu existe (voir les <a href="../modeles-recommandes/pages-comptes-rendu-rendement-services-insitutionnels.html">Pages de compte rendu du rendement des services institutionnels</a>)</li>
-												<li>Il mène à la page d’accueil des comptes rendus de l’institution</li>
-											</ul>
-										</dd>
-									</dl>
-								</li>
-							</ul>
-						</details>
-					</li>
-					<li id="element22">
-						<details class="mrgn-bttm-sm">
-							<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Présentation</strong></summary>
-							<ul>
-								<li>Cette composante est affichée au-dessus de la section «&nbsp;En vedette&nbsp;».</li>
-							</ul>
-						</details>
-					</li>
-				</ul>
-			</section>
-			<section>
-				<h4>12a&nbsp;: Ministre d’un ministère ou chef d’une institution quasi judiciaire sans lien de dépendance</h4>
-				<p><span class="label label-warning">Conditionelle</span></p>
-				<p>Fournit le profil de chaque ministre ou chef d’institution</p>
-				<ul class="list-unstyled">
-					<li id="element23">
-						<details class="mrgn-bttm-sm">
-							<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Contenu</strong></summary>
-							<ul>
-								<li>Cette composante est obligatoire pour toutes les institutions, sauf si vous utilisez la composante Ministres du portefeuille (12b).</li>
-								<li>Elle fournit des images assorties d’hyperliens menant soit au(x) ministre(s) de l’institution (y compris les ministres associés), soit au chef de l’institution (dans le cas des institutions indépendantes ou quasi judiciaires). </li>
-								<li>Les images et les textes sont assortis d’un hyperlien menant à la page de profil ministériel pertinente (voir  les <a href="./pages-profil-ministres.html">pages de profil des ministres</a>).</li>
-								<li>Le texte de l’hyperlien se limite au titre honorifique («&nbsp;L’honorable&nbsp;») et aux prénom et nom du ou de la ministre ou du chef de l’institution.</li>
-								<li>Le texte non assorti d’un hyperlien se limite au titre officiel du ministre ou du chef de l’institution.</li>
-								<li>Les en-têtes suivants doivent être présentés au-dessus du fonctionnaire élu approprié&nbsp;:
-									<ul>
-										<li>«&nbsp;Ministre&nbsp;»</li>
-										<li>«&nbsp;Secrétaire parlementaire&nbsp;»</li>
-										<li>«&nbsp;Ministre associé&nbsp;»</li>
-									</ul>
-								</li>
-								<li>L’en-tête «&nbsp;Direction&nbsp;» ou «&nbsp;Ombudsman&nbsp;» doit être présenté, au besoin, au-dessus du haut fonctionnaire qui est le chef de l’institution.</li>
-							</ul>
-						</details>
-					</li>
-					<li id="element24">
-						<details class="mrgn-bttm-sm">
-							<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Présentation</strong></summary>
-							<ul>
-								<li>Cette composante figure à droite de «Renseignements organisationnels&nbsp;».</li>
-								<li>Les sujets sont présentés en ordre de priorité, de gauche à droite.</li>
-								<li>Lorsque plus de trois images sont requises, continuez sur une deuxième ligne.</li>
-								<li>Lorsque moins de trois images sont requises, l’image doit être justifiée à gauche de la section «&nbsp;Renseignements organisationnels&nbsp;».</li>
-								<li>Consultez la <a href="http://wet-boew.github.io/themes-dist/GCWeb/index-fr.html">page GitHub sur Canada.ca</a> pour obtenir des détails sur la taille des images.</li>
-							</ul>
-						</details>
-					</li>
-				</ul>
-			</section>
-			<section>
-				<h4>13&nbsp;: Section «&nbsp;En vedette&nbsp;» de l’institution</h4>
-				<p><span class="label label-info">Facultative</span></p>
-				<p>Fait la promotion des activités en cours de l’institution et menées par celle-ci</p>
-				<ul class="list-unstyled">
-					<li id="element25">
-						<details class="mrgn-bttm-sm">
-							<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Contenu</strong></summary>
-							<ul>
-								<li>Utilisez la configuration <a href="../configurations-conception-communes/vignettes-promotionnelles.html">Promotions contextuelles</a>.</li>
-							</ul>
-						</details>
-					</li>
-					<li id="element26">
-						<details class="mrgn-bttm-sm">
-							<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Présentation</strong></summary>
-							<ul>
-								<li>L’étiquette de l’en-tête est «&nbsp;En vedette&nbsp;».</li>
-							</ul>
-						</details>
-					</li>
-				</ul>
-			</section>
-		</section>
-	</div>
-</div>
-<h3 id="identification">Comment utiliser l'identification d’un organisme indépendant</h3>
-<div class="btn-group mrgn-bttm-sm">
-	<button type="button" class="btn btn-default wb-toggle" data-toggle="{&quot;selector&quot;: &quot;details&quot;, &quot;parent&quot;: &quot;#template-elements2&quot;, &quot;type&quot;: &quot;on&quot;}">Développer tout</button>
-	<button type="button" class="btn btn-default wb-toggle" data-toggle="{&quot;selector&quot;: &quot;details&quot;, &quot;parent&quot;: &quot;#template-elements2&quot;, &quot;type&quot;: &quot;off&quot;}">Réduire tout</button>
-</div>
-<div class="row">
-	<div class="col-lg-6 pull-right">
-		<figure class="mrgn-bttm-lg">
-			<figcaption class="text-center"><b>Modèle d’identification indépendante</b></figcaption>
-			<img src="https://www.canada.ca/content/dam/tbs-sct/images/government-communications/canada-content-style-guide/arms-length-branding-fra.jpg" class="full-width" alt="Image de l’identification indépendante indiquant les composants de sa structure. Lire de haut en bas et de gauche à droite. Plus de détails au sujet de ce graphique se retrouvent dans le texte entourant l’image."> </figure>
-	</div>
-	<div class="col-lg-6 pull-left">
-		<section id="template-elements2">
-			<section>
-				<h4>2b&nbsp;: Image de marque de l’organisme indépendant</h4>
-				<p><span class="label label-warning">Conditionelle</span></p>
-				<p>Affiche l’identificateur approuvé des institutions qui satisfont aux critères d’indépendance</p>
-				<ul class="list-unstyled">
-					<li id="element2-1">
-						<details class="mrgn-bttm-sm">
-							<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Contenu</strong></summary>
-							<ul>
-								<li>Cette composante est conditionnelle. Seules les institutions qui font partie de la catégorie des tribunaux administratifs selon les <a href="http://www.appointments-nominations.gc.ca/prsnt.asp?menu=2&amp;page=gicIntro&amp;lang=fra">règles sur les nominations par le gouverneur en conseil</a> ont l’option d’afficher leur identificateur d’image de marque approuvé.</li>
-								<li>Les institutions faisant partie de la catégorie des agences et conseils qui ont pour mandat de rendre des décisions exécutoires peuvent aussi avoir l’option d’afficher leur identificateur d’image de marque approuvé, tel que déterminé au cas par cas par les organismes centraux.</li>
-								<li>L’image de marque doit être conforme aux règles du Programme de coordination de l’image de marque (PCIM) sur l’identification des institutions fédérales.</li>
-							</ul>
-						</details>
-					</li>
-					<li id="element2-2">
-						<details class="mrgn-bttm-sm">
-							<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Présentation</strong></summary>
-							<ul>
-								<li>L’image de marque figure en haut de la page.</li>
-								<li>Elle doit être formatée conformément aux spécifications de conception du PCIM, s’il y a lieu (cela s’applique aux institutions qui ne sont pas exemptées du PCIM).</li>
-								<li>Elle doit être configurée de manière à s’adapter automatiquement à la taille de l’écran (SVG est le format recommandé), conformément aux principes de conception adaptée.</li>
-								<li>L’image n’est pas assortie d’un hyperlien.</li>
-							</ul>
-						</details>
-					</li>
-				</ul>
-			</section>
-			<section>
-				<h4>3a&nbsp;: Énoncé de l’organisme indépendant</h4>
-				<p><span class="label label-warning">Conditionelle</span></p>
-				<p>Explique la nature indépendante de l’institution</p>
-				<ul class="list-unstyled">
-					<li id="element2-3">
-						<details class="mrgn-bttm-sm">
-							<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Contenu</strong></summary>
-							<ul>
-								<li>Cette composante est conditionnelle. Seules les institutions qui font partie de la catégorie des tribunaux administratifs selon les <a href="http://www.appointments-nominations.gc.ca/prsnt.asp?menu=2&amp;page=gicIntro&amp;lang=fra">règles sur les nominations par le gouverneur en conseil</a> ont l’option d’afficher l’énoncé d’indépendance.</li>
-								<li>Les institutions faisant partie de la catégorie des agences et conseils qui ont pour mandat de rendre des décisions exécutoires peuvent aussi avoir l’option d’afficher cet énoncé, tel que déterminé au cas par cas par les organismes centraux.</li>
-								<li>Cet énoncé fournit une brève explication de la nature autonome de l’organisme indépendant.</li>
-							</ul>
-						</details>
-					</li>
-					<li id="element2-4">
-						<details class="mrgn-bttm-sm">
-							<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Présentation</strong></summary>
-							<ul>
-								<li>Il figure en caractères gras.</li>
-							</ul>
-						</details>
-					</li>
-				</ul>
-			</section>
-		</section>
-	</div>
-</div>
+					<h3>Version stable de la page d'accueil institutionnelle</h3>
+					<p>La version stable sera éventuellement remplacée par la version bêta.</p>
+					<details>
+						<summary>Directives pour la version stable de la page d'accueil institutionnelle</summary>
+						<h3 id="profil">Page de profil</h3>
+						<p>Toutes les institutions mentionnées aux annexes I, I.1 et II de la <a href="http://laws-lois.justice.gc.ca/fra/lois/f-11/">Loi sur la gestion des finances publiques</a>&nbsp;(LGFP) doivent élaborer un profil institutionnel. Tous ces profils font partie de la page des ministères et organismes (voir la section sur la <a href="./page-ministeres-organismes.html">page des ministères et organismes</a>).</p>
+						<div class="btn-group mrgn-bttm-sm">
+							<button type="button" class="btn btn-default wb-toggle" data-toggle="{&quot;selector&quot;: &quot;details&quot;, &quot;parent&quot;: &quot;#template-elements&quot;, &quot;type&quot;: &quot;on&quot;}">Développer tout</button>
+							<button type="button" class="btn btn-default wb-toggle" data-toggle="{&quot;selector&quot;: &quot;details&quot;, &quot;parent&quot;: &quot;#template-elements&quot;, &quot;type&quot;: &quot;off&quot;}">Réduire tout</button>
+						</div>
+						<div class="row">
+							<div class="col-lg-6 pull-right">
+								<figure class="mrgn-bttm-lg">
+									<figcaption class="text-center"><b>Modèle de la page de profil institutionnel</b></figcaption>
+									<img src="https://www.canada.ca/content/dam/tbs-sct/images/government-communications/canada-content-style-guide/institutional-profile-fra-02.jpg" class="full-width" alt="Modèle de la page de profil institutionnel pour les grandes institutions indiquant les parties qui composent sa structure. Lire de haut en bas et de gauche à droite. Plus de détails au sujet de ce graphique se retrouvent dans le texte entourant l’image.">
+								</figure>
+							</div>
+							<div class="col-lg-6 pull-left">
+								<section id="template-elements">
+									<section>
+										<h4>1&nbsp;: Nom de l’institution</h4>
+										<p><span class="label label-danger">Obligatoire</span></p>
+										<p>Fournit le titre d’usage de l’institution</p>
+										<ul class="list-unstyled">
+											<li id="element1">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Contenu</strong></summary>
+													<ul>
+														<li>Utilisez le titre d’usage de l’institution indiqué dans le <a href="https://www.tbs-sct.gc.ca/hgw-cgf/oversight-surveillance/communications/fip-pcim/reg-fra.asp">Registre des titres d’usage</a>.</li>
+														<li>Utilisez le titre légal si le titre d’usage n’est pas disponible.</li>
+														<li>N’utilisez pas d’acronymes ou d’abréviations.</li>
+													</ul>
+												</details>
+											</li>
+											<li id="element2">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Présentation</strong></summary>
+													<ul>
+														<li>Le titre du profil institutionnel doit être une balise H1 unique.</li>
+														<li>Il doit être la première composante de la page.</li>
+													</ul>
+												</details>
+											</li>
+										</ul>
+									</section>
+									<section>
+										<h4>2a&nbsp;: Insigne</h4>
+										<p><span class="label label-warning">Conditionelle</span></p>
+										<p>Fournit l’identification de la Gendarmerie royale du Canada</p>
+										<ul class="list-unstyled">
+											<li id="element3">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Contenu</strong></summary>
+													<ul>
+														<li>Seule la Gendarmerie royale du Canada peut utiliser cette composante pour afficher son insigne approuvé.</li>
+													</ul>
+												</details>
+											</li>
+											<li id="element4">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Présentation</strong></summary>
+													<ul>
+														<li>L’insigne se trouve à la droite du mandat de l’institution.</li>
+														<li>L’image n’est pas assortie d’un hyperlien.</li>
+													</ul>
+												</details>
+											</li>
+										</ul>
+									</section>
+									<section>
+										<h4>3&nbsp;: Mandat de l’institution</h4>
+										<p><span class="label label-danger">Obligatoire</span></p>
+										<p>Décrit en une ou deux phrases le mandat de l’institution</p>
+										<ul class="list-unstyled">
+											<li id="element5">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Contenu</strong></summary>
+													<ul>
+														<li>Elle fournit le titre d’usage de l’institution suivi d’un aperçu en langage clair de la façon dont l’institution assure des services au public.</li>
+														<li>Le texte doit être court et concis.</li>
+														<li>Le contenu est rédigé pour un niveau de scolarité secondaire (pointage de 100 et moins dans <a href="http://www.scolarius.com/">Scolarius</a>).</li>
+													</ul>
+												</details>
+											</li>
+											<li id="element6">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Présentation</strong></summary>
+													<ul>
+														<li>Le mandat de l’institution figure juste au-dessous du titre de la page du profil institutionnel.</li>
+													</ul>
+												</details>
+											</li>
+										</ul>
+									</section>
+									<section>
+										<h4>4&nbsp;: Réseaux de médias sociaux de l’institution</h4>
+										<p><span class="label label-warning">Conditionelle</span></p>
+										<p>Présente les réseaux de médias sociaux propres à l’institution</p>
+										<ul class="list-unstyled">
+											<li id="element7">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Contenu</strong></summary>
+													<ul>
+														<li>Cette composante est obligatoire pour toutes les institutions mentionnées à l’<a href="http://laws-lois.justice.gc.ca/fra/lois/F-11/page-30.html#h-74">annexe I de la LGFP</a>, et facultative pour les autres institutions.</li>
+														<li>Utilisez la configuration <a href="../configurations-conception-communes/bloc-medias-sociaux.html">Bloc des réseaux de médias sociaux (fenêtre «&nbsp;Suivez&nbsp;»)</a>.</li>
+													</ul>
+												</details>
+											</li>
+											<li id="element8">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Présentation</strong></summary>
+													<ul>
+														<li>Cette composante se trouve sous le mandat de l’institution.</li>
+													</ul>
+												</details>
+											</li>
+										</ul>
+									</section>
+									<section>
+										<h4>5&nbsp;: Nouveautés</h4>
+										<p><span class="label label-warning">Conditionelle</span></p>
+										<p>Présente les nouvelles ayant trait à l’institution</p>
+										<ul class="list-unstyled">
+											<li id="element9">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Contenu</strong></summary>
+													<ul>
+														<li>Cette composante est obligatoire pour toutes les institutions mentionnées à l’<a href="http://laws-lois.justice.gc.ca/fra/lois/F-11/page-30.html#h-74">annexe I de la LGFP</a>, et facultative pour les autres institutions.</li>
+														<li>Utilisez la configuration <a href="../configurations-conception-communes/nouveautes.html">Nouveautés</a>.</li>
+													</ul>
+												</details>
+											</li>
+											<li id="element10">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Présentation</strong></summary>
+													<ul>
+														<li>Cette composante se trouve sous «&nbsp;Réseaux de médias sociaux de l’institution&nbsp;».</li>
+													</ul>
+												</details>
+											</li>
+										</ul>
+									</section>
+									<section>
+										<h4>6&nbsp;: Services et renseignements</h4>
+										<p><span class="label label-danger">Obligatoire</span></p>
+										<p>Dresse la liste des sujets propres à l’institution</p>
+										<ul class="list-unstyled">
+											<li id="element11">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Contenu</strong></summary>
+													<ul>
+														<li>Utilisez la configuration <a href="../configurations-conception-communes/services-renseignements.html">Services et renseignements</a>.</li>
+													</ul>
+												</details>
+											</li>
+											<li id="element12">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Présentation</strong></summary>
+													<ul>
+														<li>Cette composante se trouve sous la section «&nbsp;Réseaux de médias sociaux&nbsp;» et à gauche de la section «&nbsp;En demande&nbsp;».</li>
+													</ul>
+												</details>
+											</li>
+										</ul>
+									</section>
+									<section>
+										<h4>7&nbsp;: En demande</h4>
+										<p><span class="label label-warning">Conditionelle</span></p>
+										<p>Présente les services et renseignements les plus demandés propres à l’institution</p>
+										<ul class="list-unstyled">
+											<li id="element13">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Contenu</strong></summary>
+													<ul>
+														<li>composante est obligatoire afin fournir des raccourcis vers les tâches les plus importantes de l'institution. Cependant, elle ne devrait pas être utilisée si toutes les tâches principales de l'institution sont déjà incluses en tant que liens directs sous «&nbsp;Services et renseignements&nbsp;».</li>
+														<li>Utilisez la configuration <a href="../configurations-conception-communes/en-demande.html">En demande</a>.</li>
+													</ul>
+												</details>
+											</li>
+											<li id="element14">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Présentation</strong></summary>
+													<ul>
+														<li>Cette composante figure à droite de la section «&nbsp;Services et renseignements&nbsp;».</li>
+													</ul>
+												</details>
+											</li>
+										</ul>
+									</section>
+									<section>
+										<h4>8&nbsp;: Contactez-nous</h4>
+										<p><span class="label label-danger">Obligatoire</span></p>
+										<p>Donne accès aux coordonnées de l’institution</p>
+										<ul class="list-unstyled">
+											<li id="element15">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Contenu</strong></summary>
+													<ul>
+														<li>Allez à <a href="../configurations-conception-communes/coordonnees.html">Coordonnées</a> dans les Configurations de conception communes. Utilisez, selon le cas, le modèle d’adresse ou le modèle de lien.</li>
+													</ul>
+												</details>
+											</li>
+											<li id="element16">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Présentation</strong></summary>
+													<ul>
+														<li>Cette composante est placée sous «&nbsp;Nouveautés&nbsp;» et à droite de «&nbsp;Services et renseignements&nbsp;».</li>
+													</ul>
+												</details>
+											</li>
+										</ul>
+									</section>
+									<section>
+										<h4>9&nbsp;: Autres renseignements pour les</h4>
+										<p><span class="label label-info">Facultative</span></p>
+										<p>Liens menant à des renseignements intéressant divers publics cibles</p>
+										<ul class="list-unstyled">
+											<li id="element17">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Contenu</strong></summary>
+													<ul>
+														<li>Utilisez la configuration <a href="../configurations-conception-communes/autres-renseignements.html">Autres renseignements pour les</a>.</li>
+													</ul>
+												</details>
+											</li>
+											<li id="element18">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Présentation</strong></summary>
+													<ul>
+														<li>Cette composante figure sous la section «&nbsp;En demande&nbsp;».</li>
+													</ul>
+												</details>
+											</li>
+										</ul>
+									</section>
+									<section>
+										<h4>10&nbsp;: Ce que nous faisons</h4>
+										<p><span class="label label-warning">Conditionelle</span></p>
+										<p>Fournit des liens vers le contenu relatif à l’élaboration des politiques et programmes de l’institution</p>
+										<ul class="list-unstyled">
+											<li id="element19">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Contenu</strong></summary>
+													<ul>
+														<li>Cette composante est obligatoire quand l’institution a du contenu d’élaboration de programmes et de politiques à présenter.</li>
+														<li>Utilisez la configuration <a href="../configurations-conception-communes/ce-que-nous-faisons.html">Ce que nous faisons</a>.</li>
+													</ul>
+												</details>
+											</li>
+											<li id="element20">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Présentation</strong></summary>
+													<ul>
+														<li>Cette composante figure sous la section «&nbsp;Services et renseignements&nbsp;».</li>
+													</ul>
+												</details>
+											</li>
+										</ul>
+									</section>
+									<section>
+										<h4>11&nbsp;: Renseignements organisationnels</h4>
+										<p><span class="label label-danger">Obligatoire</span></p>
+										<p>Fournit un accès uniforme aux principaux renseignements organisationnels</p>
+										<ul class="list-unstyled">
+											<li id="element21">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Contenu</strong></summary>
+													<ul>
+														<li>Cette composante consiste en une série de liens menant au contenu propre à l’institution qui n’est pas présenté ailleurs sur la page.</li>
+														<li>L’étiquette de l’en-tête est «&nbsp;Renseignements organisationnels&nbsp;».</li>
+														<li>Seuls les liens «&nbsp;Mandat&nbsp;» et «&nbsp;Transparence&nbsp;» sont obligatoires; tous les autres liens sont facultatifs.</li>
+														<li>Les liens doivent être étiquetés et ordonnés de la façon suivante&nbsp;:
+															<dl class="dl-horizontal">
+																<dt><strong>Mandat</strong></dt>
+																<dd>
+																	<ul>
+																		<li>Obligatoire</li>
+																		<li>Mène à une page présentant le mandat, la vision et les objectifs de l’institution</li>
+																	</ul>
+																</dd>
+																<dt><strong>Programmes</strong></dt>
+																<dd>
+																	<ul>
+																		<li>Facultatif</li>
+																		<li>Mène à une page fournissant la liste des programmes de l’institution</li>
+																	</ul>
+																</dd>
+																<dt><strong>Structure organisationnelle</strong></dt>
+																<dd>
+																	<ul>
+																		<li>Facultatif</li>
+																		<li>Mène à une page présentant l’organigramme ou la structure organisationnelle de l’institution</li>
+																	</ul>
+																</dd>
+																<dt><strong>Portefeuille</strong></dt>
+																<dd>
+																	<ul>
+																		<li>Facultatif</li>
+																		<li>Mène à une page présentant le portefeuille ministériel de l’institution</li>
+																	</ul>
+																</dd>
+																<dt><strong>Partenaires</strong></dt>
+																<dd>
+																	<ul>
+																		<li>Facultatif</li>
+																		<li>Mène à une page présentant les partenariats officiels de l’institution (c’est-à-dire des organisations fédérales, provinciales, territoriales, internationales ou non gouvernementales)</li>
+																	</ul>
+																</dd>
+																<dt><strong>Transparence</strong></dt>
+																<dd>
+																	<ul>
+																		<li>Obligatoire</li>
+																		<li>Mène aux renseignements sur la transparence propres à l’institution prescrits par le Secrétariat du Conseil du Trésor, comme les plans prospectifs de la réglementation et la divulgation proactive</li>
+																	</ul>
+																</dd>
+																<dt><strong>Possibilités d’emploi</strong></dt>
+																<dd>
+																	<ul>
+																		<li>Facultatif</li>
+																		<li>Mène à une page cible présentant les possibilités d’emploi au sein de l’institution</li>
+																	</ul>
+																</dd>
+																<dt><strong>Compte rendu du rendement des services</strong></dt>
+																<dd>
+																	<ul>
+																		<li>Obligatoire, si le contenu existe (voir les <a href="../modeles-recommandes/pages-comptes-rendu-rendement-services-insitutionnels.html">Pages de compte rendu du rendement des services institutionnels</a>)</li>
+																		<li>Il mène à la page d’accueil des comptes rendus de l’institution</li>
+																	</ul>
+																</dd>
+															</dl>
+														</li>
+													</ul>
+												</details>
+											</li>
+											<li id="element22">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Présentation</strong></summary>
+													<ul>
+														<li>Cette composante est affichée au-dessus de la section «&nbsp;En vedette&nbsp;».</li>
+													</ul>
+												</details>
+											</li>
+										</ul>
+									</section>
+									<section>
+										<h4>12a&nbsp;: Ministre d’un ministère ou chef d’une institution quasi judiciaire sans lien de dépendance</h4>
+										<p><span class="label label-warning">Conditionelle</span></p>
+										<p>Fournit le profil de chaque ministre ou chef d’institution</p>
+										<ul class="list-unstyled">
+											<li id="element23">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Contenu</strong></summary>
+													<ul>
+														<li>Cette composante est obligatoire pour toutes les institutions, sauf si vous utilisez la composante Ministres du portefeuille (12b).</li>
+														<li>Elle fournit des images assorties d’hyperliens menant soit au(x) ministre(s) de l’institution (y compris les ministres associés), soit au chef de l’institution (dans le cas des institutions indépendantes ou quasi judiciaires). </li>
+														<li>Les images et les textes sont assortis d’un hyperlien menant à la page de profil ministériel pertinente (voir les <a href="./pages-profil-ministres.html">pages de profil des ministres</a>).</li>
+														<li>Le texte de l’hyperlien se limite au titre honorifique («&nbsp;L’honorable&nbsp;») et aux prénom et nom du ou de la ministre ou du chef de l’institution.</li>
+														<li>Le texte non assorti d’un hyperlien se limite au titre officiel du ministre ou du chef de l’institution.</li>
+														<li>Les en-têtes suivants doivent être présentés au-dessus du fonctionnaire élu approprié&nbsp;:
+															<ul>
+																<li>«&nbsp;Ministre&nbsp;»</li>
+																<li>«&nbsp;Secrétaire parlementaire&nbsp;»</li>
+																<li>«&nbsp;Ministre associé&nbsp;»</li>
+															</ul>
+														</li>
+														<li>L’en-tête «&nbsp;Direction&nbsp;» ou «&nbsp;Ombudsman&nbsp;» doit être présenté, au besoin, au-dessus du haut fonctionnaire qui est le chef de l’institution.</li>
+													</ul>
+												</details>
+											</li>
+											<li id="element24">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Présentation</strong></summary>
+													<ul>
+														<li>Cette composante figure à droite de «Renseignements organisationnels&nbsp;».</li>
+														<li>Les sujets sont présentés en ordre de priorité, de gauche à droite.</li>
+														<li>Lorsque plus de trois images sont requises, continuez sur une deuxième ligne.</li>
+														<li>Lorsque moins de trois images sont requises, l’image doit être justifiée à gauche de la section «&nbsp;Renseignements organisationnels&nbsp;».</li>
+														<li>Consultez la <a href="http://wet-boew.github.io/themes-dist/GCWeb/index-fr.html">page GitHub sur Canada.ca</a> pour obtenir des détails sur la taille des images.</li>
+													</ul>
+												</details>
+											</li>
+										</ul>
+									</section>
+									<section>
+										<h4>13&nbsp;: Section «&nbsp;En vedette&nbsp;» de l’institution</h4>
+										<p><span class="label label-info">Facultative</span></p>
+										<p>Fait la promotion des activités en cours de l’institution et menées par celle-ci</p>
+										<ul class="list-unstyled">
+											<li id="element25">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Contenu</strong></summary>
+													<ul>
+														<li>Utilisez la configuration <a href="../configurations-conception-communes/vignettes-promotionnelles.html">Promotions contextuelles</a>.</li>
+													</ul>
+												</details>
+											</li>
+											<li id="element26">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Présentation</strong></summary>
+													<ul>
+														<li>L’étiquette de l’en-tête est «&nbsp;En vedette&nbsp;».</li>
+													</ul>
+												</details>
+											</li>
+										</ul>
+									</section>
+								</section>
+							</div>
+						</div>
+						<h3 id="identification">Comment utiliser l'identification d’un organisme indépendant</h3>
+						<div class="btn-group mrgn-bttm-sm">
+							<button type="button" class="btn btn-default wb-toggle" data-toggle="{&quot;selector&quot;: &quot;details&quot;, &quot;parent&quot;: &quot;#template-elements2&quot;, &quot;type&quot;: &quot;on&quot;}">Développer tout</button>
+							<button type="button" class="btn btn-default wb-toggle" data-toggle="{&quot;selector&quot;: &quot;details&quot;, &quot;parent&quot;: &quot;#template-elements2&quot;, &quot;type&quot;: &quot;off&quot;}">Réduire tout</button>
+						</div>
+						<div class="row">
+							<div class="col-lg-6 pull-right">
+								<figure class="mrgn-bttm-lg">
+									<figcaption class="text-center"><b>Modèle d’identification indépendante</b></figcaption>
+									<img src="https://www.canada.ca/content/dam/tbs-sct/images/government-communications/canada-content-style-guide/arms-length-branding-fra.jpg" class="full-width" alt="Image de l’identification indépendante indiquant les composants de sa structure. Lire de haut en bas et de gauche à droite. Plus de détails au sujet de ce graphique se retrouvent dans le texte entourant l’image.">
+								</figure>
+							</div>
+							<div class="col-lg-6 pull-left">
+								<section id="template-elements2">
+									<section>
+										<h4>2b&nbsp;: Image de marque de l’organisme indépendant</h4>
+										<p><span class="label label-warning">Conditionelle</span></p>
+										<p>Affiche l’identificateur approuvé des institutions qui satisfont aux critères d’indépendance</p>
+										<ul class="list-unstyled">
+											<li id="element2-1">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Contenu</strong></summary>
+													<ul>
+														<li>Cette composante est conditionnelle. Seules les institutions qui font partie de la catégorie des tribunaux administratifs selon les <a href="http://www.appointments-nominations.gc.ca/prsnt.asp?menu=2&amp;page=gicIntro&amp;lang=fra">règles sur les nominations par le gouverneur en conseil</a> ont l’option d’afficher leur identificateur d’image de marque approuvé.</li>
+														<li>Les institutions faisant partie de la catégorie des agences et conseils qui ont pour mandat de rendre des décisions exécutoires peuvent aussi avoir l’option d’afficher leur identificateur d’image de marque approuvé, tel que déterminé au cas par cas par les organismes centraux.</li>
+														<li>L’image de marque doit être conforme aux règles du Programme de coordination de l’image de marque (PCIM) sur l’identification des institutions fédérales.</li>
+													</ul>
+												</details>
+											</li>
+											<li id="element2-2">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Présentation</strong></summary>
+													<ul>
+														<li>L’image de marque figure en haut de la page.</li>
+														<li>Elle doit être formatée conformément aux spécifications de conception du PCIM, s’il y a lieu (cela s’applique aux institutions qui ne sont pas exemptées du PCIM).</li>
+														<li>Elle doit être configurée de manière à s’adapter automatiquement à la taille de l’écran (SVG est le format recommandé), conformément aux principes de conception adaptée.</li>
+														<li>L’image n’est pas assortie d’un hyperlien.</li>
+													</ul>
+												</details>
+											</li>
+										</ul>
+									</section>
+									<section>
+										<h4>3a&nbsp;: Énoncé de l’organisme indépendant</h4>
+										<p><span class="label label-warning">Conditionelle</span></p>
+										<p>Explique la nature indépendante de l’institution</p>
+										<ul class="list-unstyled">
+											<li id="element2-3">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Contenu</strong></summary>
+													<ul>
+														<li>Cette composante est conditionnelle. Seules les institutions qui font partie de la catégorie des tribunaux administratifs selon les <a href="http://www.appointments-nominations.gc.ca/prsnt.asp?menu=2&amp;page=gicIntro&amp;lang=fra">règles sur les nominations par le gouverneur en conseil</a> ont l’option d’afficher l’énoncé d’indépendance.</li>
+														<li>Les institutions faisant partie de la catégorie des agences et conseils qui ont pour mandat de rendre des décisions exécutoires peuvent aussi avoir l’option d’afficher cet énoncé, tel que déterminé au cas par cas par les organismes centraux.</li>
+														<li>Cet énoncé fournit une brève explication de la nature autonome de l’organisme indépendant.</li>
+													</ul>
+												</details>
+											</li>
+											<li id="element2-4">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Présentation</strong></summary>
+													<ul>
+														<li>Il figure en caractères gras.</li>
+													</ul>
+												</details>
+											</li>
+										</ul>
+									</section>
+								</section>
+							</div>
+						</div>
 
-<h3 id="ministres">Comment utiliser la configuration «&nbsp;ministres du portefeuille&nbsp;»</h3>
-<div class="btn-group mrgn-bttm-sm">
-	<button type="button" class="btn btn-default wb-toggle" data-toggle="{&quot;selector&quot;: &quot;details&quot;, &quot;parent&quot;: &quot;#template-elements3&quot;, &quot;type&quot;: &quot;on&quot;}">Développer tout</button>
-	<button type="button" class="btn btn-default wb-toggle" data-toggle="{&quot;selector&quot;: &quot;details&quot;, &quot;parent&quot;: &quot;#template-elements3&quot;, &quot;type&quot;: &quot;off&quot;}">Réduire tout</button>
-</div>
-<div class="row">
-	<div class="col-lg-6 pull-right">
-		<figure class="mrgn-bttm-lg">
-			<figcaption class="text-center"><b>Composant des ministres de portefeuille</b></figcaption>
-			<img src="https://www.canada.ca/content/dam/tbs-sct/images/government-communications/canada-content-style-guide/portfolio-ministers-component-fra.jpg" class="full-width" alt="Image du composant des ministres de portefeuille indiquant les éléments qui composent sa structure. Lire de haut en bas et de gauche à droite. Plus de détails au sujet de ce graphique se retrouvent dans le texte entourant l’image."> </figure>
-	</div>
-	<div class="col-lg-6 pull-left">
-		<section id="template-elements3">
-			<section>
-				<h4>12b&nbsp;: Ministres du portefeuille</h4>
-				<p><span class="label label-info">Facultative</span></p>
-				<p>Donne accès aux profils de tous les ministres du portefeuille de l’institution</p>
-				<ul class="list-unstyled">
-					<li id="element3-1">
-						<details class="mrgn-bttm-sm">
-							<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Contenu</strong></summary>
-							<ul>
-								<li>Il ne faut pas utiliser cette composante lorsqu’un seul ministre ou chef institutionnel est mentionné sous «&nbsp;Renseignements sur l’organisation&nbsp;».</li>
-								<li>Elle ne peut être utilisée que lorsqu’au moins trois ministres sont présentés.</li>
-								<li>Elle fournit des images des ministres de l’institution, assorties d’hyperliens.
-									<ul>
-										<li>Aucune photographie d’une autre personne ne peut être affichée sur le profil institutionnel.</li>
-									</ul>
-								</li>
-								<li>Les images et les textes sont assortis d’un hyperlien menant à la page de profil ministériel pertinente (voir la section sur les <a href="https://conception.canada.ca/modeles-obligatoire/pages-profil-ministres.html">pages de profil des ministres</a>).</li>
-								<li>Le texte de l’hyperlien se limite aux titre honorifique, prénom et nom du ministre&nbsp;: L’honorable [nom du ministre].</li>
-								<li>Le texte non assorti d’un hyperlien se limite au titre officiel des ministres.</li>
-							</ul>
-						</details>
-					</li>
-					<li id="element3-2">
-						<details class="mrgn-bttm-sm">
-							<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Présentation</strong></summary>
-							<ul>
-								<li>Cette composante figure au-dessus de «Renseignements organisationnels&nbsp;».</li>
-								<li>Les sujets sont présentés en ordre de priorité, de gauche à droite.</li>
-								<li>Lorsque plus de trois images sont requises, continuez la liste sur une deuxième ligne.</li>
-								<li>Consultez la <a href="http://wet-boew.github.io/themes-dist/GCWeb/index-fr.html">page GitHub sur Canada.ca</a> pour obtenir des détails sur la taille des images.</li>
-							</ul>
-						</details>
-					</li>
-				</ul>
-			</section>
-		</section>
-	</div>
-</div>
-<h3 id="organismes">Comment utiliser la configuration «&nbsp;organismes du portefeuille&nbsp;»</h3>
-<div class="btn-group mrgn-bttm-sm">
-	<button type="button" class="btn btn-default wb-toggle" data-toggle="{&quot;selector&quot;: &quot;details&quot;, &quot;parent&quot;: &quot;#template-elements4&quot;, &quot;type&quot;: &quot;on&quot;}">Développer tout</button>
-	<button type="button" class="btn btn-default wb-toggle" data-toggle="{&quot;selector&quot;: &quot;details&quot;, &quot;parent&quot;: &quot;#template-elements4&quot;, &quot;type&quot;: &quot;off&quot;}">Réduire tout</button>
-</div>
-<div class="row">
-	<div class="col-lg-6 pull-right">
-		<figure class="mrgn-bttm-lg">
-			<figcaption class="text-center"><b>Composant des organisations de portefeuille</b></figcaption>
-			<img src="https://www.canada.ca/content/dam/tbs-sct/images/government-communications/canada-content-style-guide/portfolio-organizations-component-fra.jpg" class="full-width" alt="Image du composant des organisations de portefeuille indiquant les éléments qui composent sa structure. Lire de haut en bas et de gauche à droite. Plus de détails au sujet de ce graphique se retrouvent dans le texte entourant l’image."> </figure>
-	</div>
-	<div class="col-lg-6 pull-left">
-		<section id="template-elements4">
-			<section>
-				<h4>14&nbsp;: Organismes du portefeuille</h4>
-				<p><span class="label label-info">Facultative</span></p>
-				<p>Fournit des liens vers les organismes relevant du portefeuille de l’institution</p>
-				<ul class="list-unstyled">
-					<li id="element4-1">
-						<details class="mrgn-bttm-sm">
-							<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Contenu</strong></summary>
-							<ul>
-								<li>Elle présente une liste de tous les organismes relevant du portefeuille de l’institution.</li>
-								<li>L’étiquette de l’en-tête est «&nbsp;Organismes du portefeuille&nbsp;».</li>
-								<li>Les liens doivent mener à une page de profil organisationnel (voir les <a href="./pages-profil-organisationnel.html">pages de profil organisationnel</a>).</li>
-							</ul>
-						</details>
-					</li>
-					<li id="element4-2">
-						<details class="mrgn-bttm-sm">
-							<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Présentation</strong></summary>
-							<ul>
-								<li>Cette composante figure sous «&nbsp;Ce que nous faisons&nbsp;».</li>
-							</ul>
-						</details>
-					</li>
-				</ul>
-			</section>
-		</section>
-	</div>
-</div>
-</section>
-</details>
-</section>
-<section>
-<h2 id="recherche">Recherche</h2>
-<p>L'utilisation de la version bêta de la page d'accueil institutionnelle a été testée dans le cadre de 2 projets d'optimisation réalisés avec du contenu de l'Agence de revenu du Canada.</p>
+						<h3 id="ministres">Comment utiliser la configuration «&nbsp;ministres du portefeuille&nbsp;»</h3>
+						<div class="btn-group mrgn-bttm-sm">
+							<button type="button" class="btn btn-default wb-toggle" data-toggle="{&quot;selector&quot;: &quot;details&quot;, &quot;parent&quot;: &quot;#template-elements3&quot;, &quot;type&quot;: &quot;on&quot;}">Développer tout</button>
+							<button type="button" class="btn btn-default wb-toggle" data-toggle="{&quot;selector&quot;: &quot;details&quot;, &quot;parent&quot;: &quot;#template-elements3&quot;, &quot;type&quot;: &quot;off&quot;}">Réduire tout</button>
+						</div>
+						<div class="row">
+							<div class="col-lg-6 pull-right">
+								<figure class="mrgn-bttm-lg">
+									<figcaption class="text-center"><b>Composant des ministres de portefeuille</b></figcaption>
+									<img src="https://www.canada.ca/content/dam/tbs-sct/images/government-communications/canada-content-style-guide/portfolio-ministers-component-fra.jpg" class="full-width" alt="Image du composant des ministres de portefeuille indiquant les éléments qui composent sa structure. Lire de haut en bas et de gauche à droite. Plus de détails au sujet de ce graphique se retrouvent dans le texte entourant l’image.">
+								</figure>
+							</div>
+							<div class="col-lg-6 pull-left">
+								<section id="template-elements3">
+									<section>
+										<h4>12b&nbsp;: Ministres du portefeuille</h4>
+										<p><span class="label label-info">Facultative</span></p>
+										<p>Donne accès aux profils de tous les ministres du portefeuille de l’institution</p>
+										<ul class="list-unstyled">
+											<li id="element3-1">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Contenu</strong></summary>
+													<ul>
+														<li>Il ne faut pas utiliser cette composante lorsqu’un seul ministre ou chef institutionnel est mentionné sous «&nbsp;Renseignements sur l’organisation&nbsp;».</li>
+														<li>Elle ne peut être utilisée que lorsqu’au moins trois ministres sont présentés.</li>
+														<li>Elle fournit des images des ministres de l’institution, assorties d’hyperliens.
+															<ul>
+																<li>Aucune photographie d’une autre personne ne peut être affichée sur le profil institutionnel.</li>
+															</ul>
+														</li>
+														<li>Les images et les textes sont assortis d’un hyperlien menant à la page de profil ministériel pertinente (voir la section sur les <a href="https://conception.canada.ca/modeles-obligatoire/pages-profil-ministres.html">pages de profil des ministres</a>).</li>
+														<li>Le texte de l’hyperlien se limite aux titre honorifique, prénom et nom du ministre&nbsp;: L’honorable [nom du ministre].</li>
+														<li>Le texte non assorti d’un hyperlien se limite au titre officiel des ministres.</li>
+													</ul>
+												</details>
+											</li>
+											<li id="element3-2">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Présentation</strong></summary>
+													<ul>
+														<li>Cette composante figure au-dessus de «Renseignements organisationnels&nbsp;».</li>
+														<li>Les sujets sont présentés en ordre de priorité, de gauche à droite.</li>
+														<li>Lorsque plus de trois images sont requises, continuez la liste sur une deuxième ligne.</li>
+														<li>Consultez la <a href="http://wet-boew.github.io/themes-dist/GCWeb/index-fr.html">page GitHub sur Canada.ca</a> pour obtenir des détails sur la taille des images.</li>
+													</ul>
+												</details>
+											</li>
+										</ul>
+									</section>
+								</section>
+							</div>
+						</div>
+						<h3 id="organismes">Comment utiliser la configuration «&nbsp;organismes du portefeuille&nbsp;»</h3>
+						<div class="btn-group mrgn-bttm-sm">
+							<button type="button" class="btn btn-default wb-toggle" data-toggle="{&quot;selector&quot;: &quot;details&quot;, &quot;parent&quot;: &quot;#template-elements4&quot;, &quot;type&quot;: &quot;on&quot;}">Développer tout</button>
+							<button type="button" class="btn btn-default wb-toggle" data-toggle="{&quot;selector&quot;: &quot;details&quot;, &quot;parent&quot;: &quot;#template-elements4&quot;, &quot;type&quot;: &quot;off&quot;}">Réduire tout</button>
+						</div>
+						<div class="row">
+							<div class="col-lg-6 pull-right">
+								<figure class="mrgn-bttm-lg">
+									<figcaption class="text-center"><b>Composant des organisations de portefeuille</b></figcaption>
+									<img src="https://www.canada.ca/content/dam/tbs-sct/images/government-communications/canada-content-style-guide/portfolio-organizations-component-fra.jpg" class="full-width" alt="Image du composant des organisations de portefeuille indiquant les éléments qui composent sa structure. Lire de haut en bas et de gauche à droite. Plus de détails au sujet de ce graphique se retrouvent dans le texte entourant l’image.">
+								</figure>
+							</div>
+							<div class="col-lg-6 pull-left">
+								<section id="template-elements4">
+									<section>
+										<h4>14&nbsp;: Organismes du portefeuille</h4>
+										<p><span class="label label-info">Facultative</span></p>
+										<p>Fournit des liens vers les organismes relevant du portefeuille de l’institution</p>
+										<ul class="list-unstyled">
+											<li id="element4-1">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Contenu</strong></summary>
+													<ul>
+														<li>Elle présente une liste de tous les organismes relevant du portefeuille de l’institution.</li>
+														<li>L’étiquette de l’en-tête est «&nbsp;Organismes du portefeuille&nbsp;».</li>
+														<li>Les liens doivent mener à une page de profil organisationnel (voir les <a href="./pages-profil-organisationnel.html">pages de profil organisationnel</a>).</li>
+													</ul>
+												</details>
+											</li>
+											<li id="element4-2">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Présentation</strong></summary>
+													<ul>
+														<li>Cette composante figure sous «&nbsp;Ce que nous faisons&nbsp;».</li>
+													</ul>
+												</details>
+											</li>
+										</ul>
+									</section>
+								</section>
+							</div>
+						</div>
+				</section>
+				</details>
+				</section>
+				<section>
+					<h2 id="recherche">Recherche</h2>
+					<p>L'utilisation de la version bêta de la page d'accueil institutionnelle a été testée dans le cadre de 2 projets d'optimisation réalisés avec du contenu de l'Agence de revenu du Canada.</p>
 
-<p><a href="https://blog.canada.ca/research-summaries/cra-contact-us-research-summary.html">Research summary: Contact the CRA</a>
-</p>
-</section>
-<section>
-<h2 id="changements">Derniers changements</h2>
-<p><strong>2019-11-28 :</strong> une nouvelle version bêta de ce modèle a été ajoutée.</p>
-</section>
-<section>
-	<h2 id="discussion">Discussion</h2>
-	<p><a href="https://github.com/canada-ca/design-system-systeme-conception/issues">Discutez de ce modèle dans GitHub</a></p>
-</section>
-
-
-<div class="row pagedetails">
-<div class="col-sm-6 col-lg-4 mrgn-tp-sm">
-<div class="panel-pane pane-block pane-bean-report-problem-button"  >
-<div class="pane-content">
-<section>
-<div class="field field-name-field-bean-wetkit-body field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><a class="btn btn-default btn-block" href="https://www.canada.ca/fr/signaler-probleme.html">Signaler un problème sur cette page</a></div></div></div></section>
-</div>
-</div>
-</div>
-
-		<div class="col-sm-3 mrgn-tp-sm pull-right">
-		<div class="wb-share" data-wb-share='{&#34;lnkClass&#34;: &#34;btn btn-default btn-block&#34;}'></div>
-</div>
+					<p><a href="https://blog.canada.ca/research-summaries/cra-contact-us-research-summary.html">Research summary: Contact the CRA</a>
+					</p>
+				</section>
+				<section>
+					<h2 id="changements">Derniers changements</h2>
+					<p><strong>2019-11-28 :</strong> une nouvelle version bêta de ce modèle a été ajoutée.</p>
+				</section>
+				<section>
+					<h2 id="discussion">Discussion</h2>
+					<p><a href="https://github.com/canada-ca/design-system-systeme-conception/issues">Discutez de ce modèle dans GitHub</a></p>
+				</section>
 
 
-<div class="datemod col-xs-12 mrgn-tp-lg">
-		<dl id="wb-dtmd">
-<dt>Date de modification :</dt>
-<dd><time property="dateModified">2019-11-28</time></dd>
-</dl>
-</div>
+				<div class="row pagedetails">
+					<div class="col-sm-6 col-lg-4 mrgn-tp-sm">
+						<div class="panel-pane pane-block pane-bean-report-problem-button">
+							<div class="pane-content">
+								<section>
+									<div class="field field-name-field-bean-wetkit-body field-type-text-long field-label-hidden">
+										<div class="field-items">
+											<div class="field-item even"><a class="btn btn-default btn-block" href="https://www.canada.ca/fr/signaler-probleme.html">Signaler un problème sur cette page</a></div>
+										</div>
+									</div>
+								</section>
+							</div>
+						</div>
+					</div>
 
-</div>
-</main>
+					<div class="col-sm-3 mrgn-tp-sm pull-right">
+						<div class="wb-share" data-wb-share='{&#34;lnkClass&#34;: &#34;btn btn-default btn-block&#34;}'></div>
+					</div>
 
 
-<footer id="wb-info">
-<div class="landscape">
-<nav class="container wb-navcurr">
-<h2 class="wb-inv">Au sujet du gouvernement</h2>
-<ul class="list-unstyled colcount-sm-2 colcount-md-3">
-<li><a href="https://www.canada.ca/fr/contact.html">Contactez-nous</a></li>
-<li><a href="https://www.canada.ca/fr/gouvernement/min.html">Ministères et organismes</a></li>
-<li><a href="https://www.canada.ca/fr/gouvernement/fonctionpublique.html">Fonction publique et force militaire</a></li>
-<li><a href="https://www.canada.ca/fr/nouvelles.html">Nouvelles</a></li>
-<li><a href="https://www.canada.ca/fr/gouvernement/systeme/lois.html">Traités, lois et règlements</a></li>
-<li><a href="https://www.canada.ca/fr/transparence/rapports.html">Rapports à l'échelle du gouvernement</a></li>
-<li><a href="https://pm.gc.ca/fra">Premier ministre</a></li>
-<li><a href="https://www.canada.ca/fr/gouvernement/systeme.html">Comment le gouvernement fonctionne</a></li>
-<li><a href="https://ouvert.canada.ca/">Gouvernement ouvert</a></li>
-</ul>
-</nav>
-</div>
-<div class="brand">
-<div class="container">
-<div class="row">
-<nav class="col-md-9 col-lg-10 ftr-urlt-lnk">
-<h2 class="wb-inv">À propos du site</h2>
-<ul>
-<li><a href="https://www.canada.ca/fr/sociaux.html">Médias sociaux</a></li>
-<li><a href="https://www.canada.ca/fr/mobile.html">Applications mobiles</a></li>
-<li><a href="https://www1.canada.ca/fr/nouveausite.html">À propos de Canada.ca</a></li>
-<li><a href="https://www.canada.ca/fr/transparence/avis.html">Avis</a></li>
-<li><a href="https://www.canada.ca/fr/transparence/confidentialite.html">Confidentialité</a></li>
-</ul>
-</nav>
-<div class="col-xs-6 visible-sm visible-xs tofpg">
-<a href="#wb-cont">Haut de la page <span class="glyphicon glyphicon-chevron-up"></span></a>
-</div>
-	<div class="col-xs-6 col-md-3 col-lg-2 text-right">
-	<img src="http://www.canada.ca/etc/designs/canada/wet-boew/assets/wmms-blk.svg" alt="Symbole du gouvernement du Canada">
-	</div>
-	</div>
-	</div>
-	</div>
+					<div class="datemod col-xs-12 mrgn-tp-lg">
+						<dl id="wb-dtmd">
+							<dt>Date de modification :</dt>
+							<dd><time property="dateModified">2019-11-28</time></dd>
+						</dl>
+					</div>
+
+				</div>
+	</main>
+
+
+	<footer id="wb-info">
+		<div class="landscape">
+			<nav class="container wb-navcurr">
+				<h2 class="wb-inv">Au sujet du gouvernement</h2>
+				<ul class="list-unstyled colcount-sm-2 colcount-md-3">
+					<li><a href="https://www.canada.ca/fr/contact.html">Contactez-nous</a></li>
+					<li><a href="https://www.canada.ca/fr/gouvernement/min.html">Ministères et organismes</a></li>
+					<li><a href="https://www.canada.ca/fr/gouvernement/fonctionpublique.html">Fonction publique et force militaire</a></li>
+					<li><a href="https://www.canada.ca/fr/nouvelles.html">Nouvelles</a></li>
+					<li><a href="https://www.canada.ca/fr/gouvernement/systeme/lois.html">Traités, lois et règlements</a></li>
+					<li><a href="https://www.canada.ca/fr/transparence/rapports.html">Rapports à l'échelle du gouvernement</a></li>
+					<li><a href="https://pm.gc.ca/fra">Premier ministre</a></li>
+					<li><a href="https://www.canada.ca/fr/gouvernement/systeme.html">Comment le gouvernement fonctionne</a></li>
+					<li><a href="https://ouvert.canada.ca/">Gouvernement ouvert</a></li>
+				</ul>
+			</nav>
+		</div>
+		<div class="brand">
+			<div class="container">
+				<div class="row">
+					<nav class="col-md-9 col-lg-10 ftr-urlt-lnk">
+						<h2 class="wb-inv">À propos du site</h2>
+						<ul>
+							<li><a href="https://www.canada.ca/fr/sociaux.html">Médias sociaux</a></li>
+							<li><a href="https://www.canada.ca/fr/mobile.html">Applications mobiles</a></li>
+							<li><a href="https://www1.canada.ca/fr/nouveausite.html">À propos de Canada.ca</a></li>
+							<li><a href="https://www.canada.ca/fr/transparence/avis.html">Avis</a></li>
+							<li><a href="https://www.canada.ca/fr/transparence/confidentialite.html">Confidentialité</a></li>
+						</ul>
+					</nav>
+					<div class="col-xs-6 visible-sm visible-xs tofpg">
+						<a href="#wb-cont">Haut de la page <span class="glyphicon glyphicon-chevron-up"></span></a>
+					</div>
+					<div class="col-xs-6 col-md-3 col-lg-2 text-right">
+						<img src="http://www.canada.ca/etc/designs/canada/wet-boew/assets/wmms-blk.svg" alt="Symbole du gouvernement du Canada">
+					</div>
+				</div>
+			</div>
+		</div>
 	</footer>
 	<!--[if gte IE 9 | !IE ]><!-->
 	<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.js"></script>
@@ -1368,7 +1389,8 @@ Pages d'accueil institutionnelle - Modèle obligatoire de Canada.ca</h1>
 			<![endif]-->
 	<script src="https://www.canada.ca/etc/designs/canada/wet-boew/js/theme.min.js"></script>
 	<script>
-	document.getElementById('submissionPage').value = location.href;
-</script>
+		document.getElementById('submissionPage').value = location.href;
+	</script>
 </body>
-	</html>
+
+</html>

--- a/modeles-recommandes/transparence.html
+++ b/modeles-recommandes/transparence.html
@@ -1,187 +1,192 @@
-
-<!DOCTYPE html><!--[if lt IE 9]><html class="no-js lt-ie9" lang="en" dir="ltr"><![endif]--><!--[if gt IE 8]><!-->
+<!DOCTYPE html>
+<!--[if lt IE 9]><html class="no-js lt-ie9" lang="en" dir="ltr"><![endif]-->
+<!--[if gt IE 8]><!-->
 <html class="no-js" lang="fr" dir="ltr">
 <!--<![endif]-->
+
 <head>
-<meta charset="utf-8">
-<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+  <meta charset="utf-8">
+  <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
 		wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
-		<title>Transparence et rapports sur l'organisation - Modèle recommandé de Canada.ca - Canada.ca</title>
+  <title>Transparence et rapports sur l'organisation - Modèle recommandé de Canada.ca - Canada.ca</title>
 
-		<meta content="width=device-width,initial-scale=1" name="viewport">
+  <meta content="width=device-width,initial-scale=1" name="viewport">
 
-		<!--[if gte IE 9 | !IE ]><!-->
-<link href="https://www.canada.ca/etc/designs/canada/wet-boew/assets/favicon.ico" rel="icon" type="image/x-icon">
-<link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/css/theme.min.css"><link rel="stylesheet" href="../css/custom.css">
-<!--<![endif]-->
-<!--[if lt IE 9]>
+  <!--[if gte IE 9 | !IE ]><!-->
+  <link href="https://www.canada.ca/etc/designs/canada/wet-boew/assets/favicon.ico" rel="icon" type="image/x-icon">
+  <link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/css/theme.min.css">
+  <link rel="stylesheet" href="../css/custom.css">
+  <!--<![endif]-->
+  <!--[if lt IE 9]>
 		<link href="./GCWeb/assets/favicon.ico" rel="shortcut icon" />
 
 		<link rel="stylesheet" href="http://wet-boew.github.io/themes-dist/GCWeb/GCWeb/css/ie8-theme.min.css" />
 		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
 		<script src="./wet-boew/js/ie8-wet-boew.min.js"></script>
 		<![endif]-->
-<!--[if lte IE 9]>
+  <!--[if lte IE 9]>
 
 
 		<![endif]-->
-<noscript><link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/wet-boew/css/noscript.min.css" /></noscript>
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+  <noscript>
+    <link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/wet-boew/css/noscript.min.css" /></noscript>
+  <script>
+    (function (i, s, o, g, r, a, m) {
+    i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
+      (i[r].q = i[r].q || []).push(arguments)
+    }, i[r].l = 1 * new Date(); a = s.createElement(o),
+      m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
+    })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
 
-  ga('create', 'UA-105628416-1', 'auto');
-  ga('send', 'pageview');
+    ga('create', 'UA-105628416-1', 'auto');
+    ga('send', 'pageview');
 
-</script>
+  </script>
 
-<!-- Global site tag (gtag.js) - Google Analytics -->
+  <!-- Global site tag (gtag.js) - Google Analytics -->
 
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-105628416-3"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-105628416-3"></script>
 
-<script>
+  <script>
 
-  window.dataLayer = window.dataLayer || [];
+    window.dataLayer = window.dataLayer || [];
 
-  function gtag(){dataLayer.push(arguments);}
+    function gtag() { dataLayer.push(arguments); }
 
-  gtag('js', new Date());
+    gtag('js', new Date());
 
 
 
-  gtag('config', 'UA-105628416-3');
+    gtag('config', 'UA-105628416-3');
 
-</script>
+  </script>
 </head>
+
 <body class="cnt-wdth-lmtd" vocab="http://schema.org/" typeof="WebPage">
-<ul id="wb-tphp">
-<li class="wb-slc">
-	<a class="wb-sl" href="#wb-cont">Passer au contenu principal</a>
-</li>
-<li class="wb-slc">
-	<a class="wb-sl" href="#wb-info">Passer à «&#160;Au sujet du gouvernement&#160;»</a>
-</li>
-</ul>
-<header>
-<div id="wb-bnr" class="container">
-<section id="wb-lng" class="text-right">
-<h2 class="wb-inv">Sélection de la langue</h2>
-<div class="row">
-<div class="col-md-12">
-<ul class="list-inline margin-bottom-none">
-	<li><a lang="en" href="https://design.canada.ca/recommended-templates/transparency.html">English</a></li>
-</ul>
-</div>
-</div>
-</section>
-<div class="row">
-<div class="brand col-xs-5 col-md-4">
-<a href="https://www.canada.ca/fr.html"><img src="http://www.canada.ca/etc/designs/canada/wet-boew/assets/sig-blk-fr.svg" alt=""><span class="wb-inv"> Gouvernement du Canada / <span lang="en">Government of Canada</span></span></a>
-</div>
-<section id="wb-srch" class="col-lg-8 text-right">
-	<h2>Recherche</h2>
-<form action="https://recherche-search.gc.ca/rGs/s_r?#wb-land" method="get" role="search" class="form-inline">
+  <ul id="wb-tphp">
+    <li class="wb-slc">
+      <a class="wb-sl" href="#wb-cont">Passer au contenu principal</a>
+    </li>
+    <li class="wb-slc">
+      <a class="wb-sl" href="#wb-info">Passer à «&#160;Au sujet du gouvernement&#160;»</a>
+    </li>
+  </ul>
+  <header>
+    <div id="wb-bnr" class="container">
+      <section id="wb-lng" class="text-right">
+        <h2 class="wb-inv">Sélection de la langue</h2>
+        <div class="row">
+          <div class="col-md-12">
+            <ul class="list-inline margin-bottom-none">
+              <li><a lang="en" href="https://design.canada.ca/recommended-templates/transparency.html">English</a></li>
+            </ul>
+          </div>
+        </div>
+      </section>
+      <div class="row">
+        <div class="brand col-xs-5 col-md-4">
+          <a href="https://www.canada.ca/fr.html"><img src="http://www.canada.ca/etc/designs/canada/wet-boew/assets/sig-blk-fr.svg" alt=""><span class="wb-inv"> Gouvernement du Canada / <span lang="en">Government of Canada</span></span></a>
+        </div>
+        <section id="wb-srch" class="col-lg-8 text-right">
+          <h2>Recherche</h2>
+          <form action="https://recherche-search.gc.ca/rGs/s_r?#wb-land" method="get" role="search" class="form-inline">
 
-<div class="form-group">
+            <div class="form-group">
 
-	<label for="wb-srch-q" class="wb-inv">Rechercher dans Canada.ca</label>
+              <label for="wb-srch-q" class="wb-inv">Rechercher dans Canada.ca</label>
 
-	<input id="wb-srch-q" list="wb-srch-q-ac" class="wb-srch-q form-control" name="q" type="search" value="" size="34" maxlength="170" placeholder="Rechercher dans Canada.ca">
+              <input id="wb-srch-q" list="wb-srch-q-ac" class="wb-srch-q form-control" name="q" type="search" value="" size="34" maxlength="170" placeholder="Rechercher dans Canada.ca">
 
-<input name="st" value="s" type="hidden"/>
+              <input name="st" value="s" type="hidden" />
 
-<input name="num" value="10" type="hidden"/>
+              <input name="num" value="10" type="hidden" />
 
-<input name="langs" value="fra" type="hidden"/>
+              <input name="langs" value="fra" type="hidden" />
 
-<input name="st1rt" value="0" type="hidden">
+              <input name="st1rt" value="0" type="hidden">
 
-<input name="s5bm3ts21rch" value="x" type="hidden"/>
+              <input name="s5bm3ts21rch" value="x" type="hidden" />
 
-<datalist id="wb-srch-q-ac">
+              <datalist id="wb-srch-q-ac">
 
-<!--[if lte IE 9]><select><![endif]-->
+                <!--[if lte IE 9]><select><![endif]-->
 
-<!--[if lte IE 9]></select><![endif]-->
+                <!--[if lte IE 9]></select><![endif]-->
 
-</datalist>
+              </datalist>
 
-</div>
+            </div>
 
-<div class="form-group submit">
+            <div class="form-group submit">
 
-	<button type="submit" id="wb-srch-sub" class="btn btn-primary btn-small" name="wb-srch-sub"><span class="glyphicon-search glyphicon"></span><span class="wb-inv">Recherche</span></button>
-
-
-</div>
-
-</form>
+              <button type="submit" id="wb-srch-sub" class="btn btn-primary btn-small" name="wb-srch-sub"><span class="glyphicon-search glyphicon"></span><span class="wb-inv">Recherche</span></button>
 
 
-</section>
-</div>
-</div>
-<nav class="gweb-v2 gcweb-menu" typeof="SiteNavigationElement">
-<div class="container">
-<h2 class="wb-inv">Menu</h2>
-<button type="button" aria-haspopup="true" aria-controls="gc-mnu" aria-expanded="false">Menu<span class="wb-inv"> principal</span> <span class="expicon glyphicon glyphicon-chevron-down"></span></button>
-<ul id="gc-mnu" role="menu" aria-orientation="vertical" data-ajax-replace="https://www.canada.ca/content/dam/canada/sitemenu/sitemenu-v2-fr.html">
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/jobs.html">Emplois et milieu de travail</a></li>
+            </div>
 
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/immigration-citizenship.html">Immigration et citoyenneté</a></li>
-
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://voyage.gc.ca/">Voyage et tourisme</a></li>
-
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/entreprises.html">Entreprises et industrie</a></li>
-
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/benefits.html">Prestations</a></li>
-
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/sante.html">Santé</a></li>
-
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/impots.html">Impôts</a></li>
-
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/environnement.html">Environnement et ressources naturelles</a></li>
-
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/defense.html">Sécurité nationale et défense</a></li>
-
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/culture.html">Culture, histoire et sport</a></li>
-
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/police.html">Services de police, justice et urgences</a></li>
-
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/transport.html">Transport et infrastructure</a></li>
-
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="http://international.gc.ca/world-monde/index.aspx?lang=fra">Canada et le monde</a></li>
-
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/finance.html">Argent et finances</a></li>
-
-<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/science.html">Science et innovation</a></li>
-
-</ul>
-</div>
-</nav>
-<nav id="wb-bc" property="breadcrumb">
-<h2>Vous êtes ici :</h2>
-<div class="container">
-<ol class="breadcrumb">
-	<li><a href='https://www.canada.ca/fr.html'>Accueil</a></li>
-	<li><a href='https://www.canada.ca/fr/gouvernement/a-propos.html'>À propos de Canada.ca</a></li>
-<li><a href='https://www.canada.ca/fr/gouvernement/a-propos/systeme-conception.html'>Système de conception de Canada.ca</a></li>
-	<li><a href='https://www.canada.ca/fr/gouvernement/a-propos/systeme-conception/bibliotheque-modeles.html'>Bibliothèque de modèles et de configurations de conception</a></li>
-</ol>
-</div>
-</nav>
-</header>
+          </form>
 
 
-</div>
+        </section>
+      </div>
+    </div>
+    <nav class="gweb-v2 gcweb-menu" typeof="SiteNavigationElement">
+      <div class="container">
+        <h2 class="wb-inv">Menu</h2>
+        <button type="button" aria-haspopup="true" aria-controls="gc-mnu" aria-expanded="false">Menu<span class="wb-inv"> principal</span> <span class="expicon glyphicon glyphicon-chevron-down"></span></button>
+        <ul id="gc-mnu" role="menu" aria-orientation="vertical" data-ajax-replace="https://www.canada.ca/content/dam/canada/sitemenu/sitemenu-v2-fr.html">
+          <li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/jobs.html">Emplois et milieu de travail</a></li>
+
+          <li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/immigration-citizenship.html">Immigration et citoyenneté</a></li>
+
+          <li role="none presentation"><a role="menuitem" tabindex="-1" href="https://voyage.gc.ca/">Voyage et tourisme</a></li>
+
+          <li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/entreprises.html">Entreprises et industrie</a></li>
+
+          <li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/benefits.html">Prestations</a></li>
+
+          <li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/sante.html">Santé</a></li>
+
+          <li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/impots.html">Impôts</a></li>
+
+          <li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/environnement.html">Environnement et ressources naturelles</a></li>
+
+          <li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/defense.html">Sécurité nationale et défense</a></li>
+
+          <li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/culture.html">Culture, histoire et sport</a></li>
+
+          <li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/police.html">Services de police, justice et urgences</a></li>
+
+          <li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/transport.html">Transport et infrastructure</a></li>
+
+          <li role="none presentation"><a role="menuitem" tabindex="-1" href="http://international.gc.ca/world-monde/index.aspx?lang=fra">Canada et le monde</a></li>
+
+          <li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/finance.html">Argent et finances</a></li>
+
+          <li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/science.html">Science et innovation</a></li>
+
+        </ul>
+      </div>
+    </nav>
+    <nav id="wb-bc" property="breadcrumb">
+      <h2>Vous êtes ici :</h2>
+      <div class="container">
+        <ol class="breadcrumb">
+          <li><a href='https://www.canada.ca/fr.html'>Accueil</a></li>
+          <li><a href='https://www.canada.ca/fr/gouvernement/a-propos.html'>À propos de Canada.ca</a></li>
+          <li><a href='https://www.canada.ca/fr/gouvernement/a-propos/systeme-conception.html'>Système de conception de Canada.ca</a></li>
+          <li><a href='https://www.canada.ca/fr/gouvernement/a-propos/systeme-conception/bibliotheque-modeles.html'>Bibliothèque de modèles et de configurations de conception</a></li>
+        </ol>
+      </div>
+    </nav>
+  </header>
+
+
+  </div>
 
 
 
-</div>
-
-
+  </div>
 
 
 
@@ -194,66 +199,68 @@
 
 
 
-<!--/* Hide Nav; Hide Right Rail /*-->
-
-<main role="main" property="mainContentOfPage" class="container wb-prettify all-pre">
-	<h1 property="name" id="wb-cont" dir="ltr">Transparence et rapports sur l'organisation - Modèle recommandé de Canada.ca</h1>
-	<p class="gc-byline"><strong>De : <a href="https://www.canada.ca/fr/secretariat-conseil-tresor.html">Secrétariat du Conseil du Trésor du Canada</a></strong></p>
-
-	<p>Une page de rapport sur l'organisation fournit une divulgation proactive des renseignements offerts par cette institution.</p>
-	<p>Le modèle de page de rapports sur l'organisation : </p>
-	<ul>
-		<li>appuie une approche cohérente de la présentation des renseignements liée à la production de rapports sur l'organisation;</li>
-		<li>favorise l'achèvement des tâches en donnant la priorité à l'accès aux tâches liées à la déclaration des renseignements sur l'organisation;</li>
-		<li>complète les objectifs des pages d'accueil institutionnelles en offrant des renseignements connexe propre aux institutions sur la divulgation proactive;</li>
-		<li>limite la quantité de contenu utilisée pour décrire la divulgation proactive.</li>
-	</ul>
 
 
-	<section>
-		<h2>Sur cette page</h2>
-		<ul>
-			<li><a href="#quand">Quand l'utiliser</a></li>
-			<li><a href="#eviter">Quoi éviter</a></li>
-			<li><a href="#comment">Comment mettre en œuvre ce modèle</a></li>
-			<li><a href="#discussion">Discussion</a></li>
-		</ul>
-	</section>
+  <!--/* Hide Nav; Hide Right Rail /*-->
 
-	<section>
-		<h2 id="quand">Quand l'utiliser</h2>
-		<p>Utilisez ce modèle comme page d'accueil sur la transparence et les rapports sur l'organisation pour les institutions et les organisations du gouvernement du Canada.</p>
-	</section>
+  <main role="main" property="mainContentOfPage" class="container wb-prettify all-pre">
+    <h1 property="name" id="wb-cont" dir="ltr">Transparence et rapports sur l'organisation - Modèle recommandé de Canada.ca</h1>
+    <p class="gc-byline"><strong>De : <a href="https://www.canada.ca/fr/secretariat-conseil-tresor.html">Secrétariat du Conseil du Trésor du Canada</a></strong></p>
 
-	<section>
-		<h2 id="eviter">Quoi éviter</h2>
-		<p>Utiliser ce modèle une seule fois par institution.</p>
-	</section>
-
-	<section>
-		<h2 id="comment">Comment mettre en œuvre ce modèle</h2>
-		<div class="row mrgn-tp-lg mrgn-bttm-lg">
-			<div class="col-xs-10 col-sm-10 col-md-8 col-lg-8">
-					<div class="gc-dwnld">
-						<div class="row">
-							<div class="col-xs-10 col-sm-3 col-md-3 col-lg-2">
-								<p><a class="gc-dwnld-lnk" href="../mise-en-page/transparence_directives.html"><img class="thumbnail gc-dwnld-img" src="../images/transparency-fr-cropped.png" alt="" width="110" height="142"></a></p>
-							</div>
-							<div class="col-xs-12 col-sm-9 col-md-9 col-lg-10">
-								<p style="font-size:24px;line-height:1em;" class="mrgn-tp-md"><span>Transparence et rapports sur l'organisation</span></p>
-								<p><a class="btn btn-call-to-action" href="../mise-en-page/transparence_directives.html">Modèle avec directives</a></p>
-								<!-- <p class="mrgn-tp-md" style="line-height:3em;"><a class="btn btn-primary mrgn-rght-sm" href="citizenship-test/study-guide.html" role="button">Start studying</a></p> -->
-								<!--<p class="mrgn-tp-lg">or <a class="gc-dwnld-lnk" href="citizenship-test/study-guide.html">download the PDF version</a></p>-->
-							</div>
-						</div><!-- .row -->
-					</div><!-- .well gc-dwnld -->
-			</div><!-- .col-sm-8 -->
-		</div>
+    <p>Une page de rapport sur l'organisation fournit une divulgation proactive des renseignements offerts par cette institution.</p>
+    <p>Le modèle de page de rapports sur l'organisation : </p>
+    <ul>
+      <li>appuie une approche cohérente de la présentation des renseignements liée à la production de rapports sur l'organisation;</li>
+      <li>favorise l'achèvement des tâches en donnant la priorité à l'accès aux tâches liées à la déclaration des renseignements sur l'organisation;</li>
+      <li>complète les objectifs des pages d'accueil institutionnelles en offrant des renseignements connexe propre aux institutions sur la divulgation proactive;</li>
+      <li>limite la quantité de contenu utilisée pour décrire la divulgation proactive.</li>
+    </ul>
 
 
-		<details>
-			<summary>Code</summary>
-			<pre class="prettyprint"><code>&#x3C;h1 property=&#x22;name&#x22; id=&#x22;wb-cont&#x22;&#x3E;Transparence: [Institution]&#x3C;/h1&#x3E;
+    <section>
+      <h2>Sur cette page</h2>
+      <ul>
+        <li><a href="#quand">Quand l'utiliser</a></li>
+        <li><a href="#eviter">Quoi éviter</a></li>
+        <li><a href="#comment">Comment mettre en œuvre ce modèle</a></li>
+        <li><a href="#discussion">Discussion</a></li>
+      </ul>
+    </section>
+
+    <section>
+      <h2 id="quand">Quand l'utiliser</h2>
+      <p>Utilisez ce modèle comme page d'accueil sur la transparence et les rapports sur l'organisation pour les institutions et les organisations du gouvernement du Canada.</p>
+    </section>
+
+    <section>
+      <h2 id="eviter">Quoi éviter</h2>
+      <p>Utiliser ce modèle une seule fois par institution.</p>
+    </section>
+
+    <section>
+      <h2 id="comment">Comment mettre en œuvre ce modèle</h2>
+      <div class="row mrgn-tp-lg mrgn-bttm-lg">
+        <div class="col-xs-10 col-sm-10 col-md-8 col-lg-8">
+          <div class="gc-dwnld">
+            <div class="row">
+              <div class="col-xs-10 col-sm-3 col-md-3 col-lg-2">
+                <p><a class="gc-dwnld-lnk" href="../mise-en-page/transparence_directives.html"><img class="thumbnail gc-dwnld-img" src="../images/transparency-fr-cropped.png" alt="" width="110" height="142"></a></p>
+              </div>
+              <div class="col-xs-12 col-sm-9 col-md-9 col-lg-10">
+                <p style="font-size:24px;line-height:1em;" class="mrgn-tp-md"><span>Transparence et rapports sur l'organisation</span></p>
+                <p><a class="btn btn-call-to-action" href="../mise-en-page/transparence_directives.html">Modèle avec directives</a></p>
+                <!-- <p class="mrgn-tp-md" style="line-height:3em;"><a class="btn btn-primary mrgn-rght-sm" href="citizenship-test/study-guide.html" role="button">Start studying</a></p> -->
+                <!--<p class="mrgn-tp-lg">or <a class="gc-dwnld-lnk" href="citizenship-test/study-guide.html">download the PDF version</a></p>-->
+              </div>
+            </div><!-- .row -->
+          </div><!-- .well gc-dwnld -->
+        </div><!-- .col-sm-8 -->
+      </div>
+
+
+      <details>
+        <summary>Code</summary>
+        <pre class="prettyprint"><code>&#x3C;h1 property=&#x22;name&#x22; id=&#x22;wb-cont&#x22;&#x3E;Transparence: [Institution]&#x3C;/h1&#x3E;
 &#x3C;p class=&#x22;pagetag&#x22;&#x3E;Divulgation proactive de l&#x2019;information de [institution], qui est rendue publique afin que la population canadienne et le Parlement soient mieux en mesure de demander des comptes au gouvernement et aux repr&#xE9;sentants du secteur public.&#x3C;/p&#x3E;
  &#x3C;section&#x3E;
    &#x3C;div class=&#x22;row wb-eqht mrgn-bttm-md&#x22;&#x3E;
@@ -351,40 +358,45 @@
    &#x3C;/div&#x3E;
   &#x3C;/section&#x3E;
  &#x3C;/section&#x3E;</code></pre>
-		</details>
+      </details>
 
-		<section>
-			<h2 id="discussion">Discussion</h2>
-			<p><a href="https://github.com/canada-ca/design-system-systeme-conception/issues">Discutez de ce modèle dans GitHub</a></p>
-		</section>
-
-
-	</section> <!-- end of pattern-demo -->
-
-<div class="row pagedetails">
-<div class="col-sm-6 col-lg-4 mrgn-tp-sm">
-<div class="panel-pane pane-block pane-bean-report-problem-button"  >
-<div class="pane-content">
-<section>
-<div class="field field-name-field-bean-wetkit-body field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><a class="btn btn-default btn-block" href="https://www.canada.ca/fr/signaler-probleme.html">Signaler un problème sur cette page</a></div></div></div></section>
-</div>
-</div>
-</div>
-
-		<div class="col-sm-3 mrgn-tp-sm pull-right">
-		<div class="wb-share" data-wb-share='{&#34;lnkClass&#34;: &#34;btn btn-default btn-block&#34;}'></div>
-</div>
+      <section>
+        <h2 id="discussion">Discussion</h2>
+        <p><a href="https://github.com/canada-ca/design-system-systeme-conception/issues">Discutez de ce modèle dans GitHub</a></p>
+      </section>
 
 
-<div class="datemod col-xs-12 mrgn-tp-lg">
-		<dl id="wb-dtmd">
-<dt>Date de modification :</dt>
-<dd><time property="dateModified">2019-11-28</time></dd>
-</dl>
-</div>
+    </section> <!-- end of pattern-demo -->
 
-</div>
-</main>
+    <div class="row pagedetails">
+      <div class="col-sm-6 col-lg-4 mrgn-tp-sm">
+        <div class="panel-pane pane-block pane-bean-report-problem-button">
+          <div class="pane-content">
+            <section>
+              <div class="field field-name-field-bean-wetkit-body field-type-text-long field-label-hidden">
+                <div class="field-items">
+                  <div class="field-item even"><a class="btn btn-default btn-block" href="https://www.canada.ca/fr/signaler-probleme.html">Signaler un problème sur cette page</a></div>
+                </div>
+              </div>
+            </section>
+          </div>
+        </div>
+      </div>
+
+      <div class="col-sm-3 mrgn-tp-sm pull-right">
+        <div class="wb-share" data-wb-share='{&#34;lnkClass&#34;: &#34;btn btn-default btn-block&#34;}'></div>
+      </div>
+
+
+      <div class="datemod col-xs-12 mrgn-tp-lg">
+        <dl id="wb-dtmd">
+          <dt>Date de modification :</dt>
+          <dd><time property="dateModified">2019-11-28</time></dd>
+        </dl>
+      </div>
+
+    </div>
+  </main>
 
 
 
@@ -394,57 +406,58 @@
 
 
 
-<footer id="wb-info">
-<div class="landscape">
-<nav class="container wb-navcurr">
-<h2 class="wb-inv">Au sujet du gouvernement</h2>
-<ul class="list-unstyled colcount-sm-2 colcount-md-3">
-<li><a href="https://www.canada.ca/fr/contact.html">Contactez-nous</a></li>
-<li><a href="https://www.canada.ca/fr/gouvernement/min.html">Ministères et organismes</a></li>
-<li><a href="https://www.canada.ca/fr/gouvernement/fonctionpublique.html">Fonction publique et force militaire</a></li>
-<li><a href="https://www.canada.ca/fr/nouvelles.html">Nouvelles</a></li>
-<li><a href="https://www.canada.ca/fr/gouvernement/systeme/lois.html">Traités, lois et règlements</a></li>
-<li><a href="https://www.canada.ca/fr/transparence/rapports.html">Rapports à l'échelle du gouvernement</a></li>
-<li><a href="https://pm.gc.ca/fra">Premier ministre</a></li>
-<li><a href="https://www.canada.ca/fr/gouvernement/systeme.html">Comment le gouvernement fonctionne</a></li>
-<li><a href="https://ouvert.canada.ca/">Gouvernement ouvert</a></li>
-</ul>
-</nav>
-</div>
-<div class="brand">
-<div class="container">
-<div class="row">
-<nav class="col-md-9 col-lg-10 ftr-urlt-lnk">
-<h2 class="wb-inv">À propos du site</h2>
-<ul>
-<li><a href="https://www.canada.ca/fr/sociaux.html">Médias sociaux</a></li>
-<li><a href="https://www.canada.ca/fr/mobile.html">Applications mobiles</a></li>
-<li><a href="https://www1.canada.ca/fr/nouveausite.html">À propos de Canada.ca</a></li>
-<li><a href="https://www.canada.ca/fr/transparence/avis.html">Avis</a></li>
-<li><a href="https://www.canada.ca/fr/transparence/confidentialite.html">Confidentialité</a></li>
-</ul>
-</nav>
-<div class="col-xs-6 visible-sm visible-xs tofpg">
-<a href="#wb-cont">Haut de la page <span class="glyphicon glyphicon-chevron-up"></span></a>
-</div>
-	<div class="col-xs-6 col-md-3 col-lg-2 text-right">
-	<img src="http://www.canada.ca/etc/designs/canada/wet-boew/assets/wmms-blk.svg" alt="Symbole du gouvernement du Canada">
-	</div>
-	</div>
-	</div>
-	</div>
-	</footer>
-	<!--[if gte IE 9 | !IE ]><!-->
-	<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.js"></script>
-	<script src="https://wet-boew.github.io/themes-dist/GCWeb/wet-boew/js/wet-boew.min.js"></script>
-	<!--<![endif]-->
-	<!--[if lt IE 9]>
+  <footer id="wb-info">
+    <div class="landscape">
+      <nav class="container wb-navcurr">
+        <h2 class="wb-inv">Au sujet du gouvernement</h2>
+        <ul class="list-unstyled colcount-sm-2 colcount-md-3">
+          <li><a href="https://www.canada.ca/fr/contact.html">Contactez-nous</a></li>
+          <li><a href="https://www.canada.ca/fr/gouvernement/min.html">Ministères et organismes</a></li>
+          <li><a href="https://www.canada.ca/fr/gouvernement/fonctionpublique.html">Fonction publique et force militaire</a></li>
+          <li><a href="https://www.canada.ca/fr/nouvelles.html">Nouvelles</a></li>
+          <li><a href="https://www.canada.ca/fr/gouvernement/systeme/lois.html">Traités, lois et règlements</a></li>
+          <li><a href="https://www.canada.ca/fr/transparence/rapports.html">Rapports à l'échelle du gouvernement</a></li>
+          <li><a href="https://pm.gc.ca/fra">Premier ministre</a></li>
+          <li><a href="https://www.canada.ca/fr/gouvernement/systeme.html">Comment le gouvernement fonctionne</a></li>
+          <li><a href="https://ouvert.canada.ca/">Gouvernement ouvert</a></li>
+        </ul>
+      </nav>
+    </div>
+    <div class="brand">
+      <div class="container">
+        <div class="row">
+          <nav class="col-md-9 col-lg-10 ftr-urlt-lnk">
+            <h2 class="wb-inv">À propos du site</h2>
+            <ul>
+              <li><a href="https://www.canada.ca/fr/sociaux.html">Médias sociaux</a></li>
+              <li><a href="https://www.canada.ca/fr/mobile.html">Applications mobiles</a></li>
+              <li><a href="https://www1.canada.ca/fr/nouveausite.html">À propos de Canada.ca</a></li>
+              <li><a href="https://www.canada.ca/fr/transparence/avis.html">Avis</a></li>
+              <li><a href="https://www.canada.ca/fr/transparence/confidentialite.html">Confidentialité</a></li>
+            </ul>
+          </nav>
+          <div class="col-xs-6 visible-sm visible-xs tofpg">
+            <a href="#wb-cont">Haut de la page <span class="glyphicon glyphicon-chevron-up"></span></a>
+          </div>
+          <div class="col-xs-6 col-md-3 col-lg-2 text-right">
+            <img src="http://www.canada.ca/etc/designs/canada/wet-boew/assets/wmms-blk.svg" alt="Symbole du gouvernement du Canada">
+          </div>
+        </div>
+      </div>
+    </div>
+  </footer>
+  <!--[if gte IE 9 | !IE ]><!-->
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.js"></script>
+  <script src="https://wet-boew.github.io/themes-dist/GCWeb/wet-boew/js/wet-boew.min.js"></script>
+  <!--<![endif]-->
+  <!--[if lt IE 9]>
 			<script src="./wet-boew/js/ie8-wet-boew2.min.js"></script>
 
 			<![endif]-->
-	<script src="https://www.canada.ca/etc/designs/canada/wet-boew/js/theme.min.js"></script>
-	<script>
-	document.getElementById('submissionPage').value = location.href;
-</script>
+  <script src="https://www.canada.ca/etc/designs/canada/wet-boew/js/theme.min.js"></script>
+  <script>
+    document.getElementById('submissionPage').value = location.href;
+  </script>
 </body>
-	</html>
+
+</html>


### PR DESCRIPTION
Because:
- Instutional landing pages were using `p` tag in `figure`
- Some grid elements weren't properly nested

Replaced `figure` tag with `div` and `figcaption` for `h3`. Some `.row`
weren't nested in `.container` properly. `.col-md-12` was used as a fix
for the lack of `.container` class.
