### PR TITLE
Remove Bêta label from cases-cocher-boutons-radio.html

### DIFF
--- a/configurations-conception-communes/cases-cocher-boutons-radio.html
+++ b/configurations-conception-communes/cases-cocher-boutons-radio.html
@@ -128,7 +128,6 @@
   <div class="row">
     <div class="col-md-12 pull-left">
       <ul class="list-inline small mrgn-bttm-sm" style="line-height:1.65em" id="list-inline-desktop-only">
-        <li class="mrgn-rght-lg"> <span class="label label-info">Bêta</span></li>
         <li class="mrgn-rght-lg"> Dernière modification : 2020-10-21</li>
       </ul>
     </div>


### PR DESCRIPTION
Removing the Bêta label as this pattern is not beta anymore. The PP code is stable and the GCweb documentation doesn't say anything about it being provisional (https://wet-boew.github.io/GCWeb/components/gc-chckbxrdio/gc-chckbxrdio-doc-fr.html)

English PR: https://github.com/canada-ca/design-system/pull/283