### PR TITLE
Update signature.md

### DIFF
--- a/configurations-conception-communes/en-tete-global/signature.md
+++ b/configurations-conception-communes/en-tete-global/signature.md
@@ -136,9 +136,9 @@ title: "Signature du gouvernement du Canada"
 <p>Si vous souhaitez en savoir plus au sujet de cette recherche, communiquez avec le Bureau de la transformation numérique à <a href="mailto:dto.btn@tbs-sct.gc.ca">dto.btn@tbs-sct.gc.ca</a>.</p>
 
 <h3>Justification stratégique</h3>
-<p>La signature du gouvernement du Canada est définie par le Programme de coordination de l’image de marque. En tant que partie de l’en-tête général, il s’agit d’un élément obligatoire de la <cite>spécification du contenu et de l’architecture de l’information.</cite></p>
+<p>La signature du gouvernement du Canada est définie par le Programme fédéral de l’image de marque. En tant que partie de l’en-tête général, il s’agit d’un élément obligatoire de la <cite>spécification du contenu et de l’architecture de l’information.</cite></p>
 <ul>
-  <li><a href="https://www.canada.ca/fr/secretariat-conseil-tresor/services/communications-gouvernementales/norme-graphique/couleurs-norme-graphique-pfim.html">Norme graphique du Programme de coordination de l’image de marque</a></li>
+  <li><a href="https://www.canada.ca/fr/secretariat-conseil-tresor/services/communications-gouvernementales/norme-graphique/couleurs-norme-graphique-pfim.html">Norme graphique du Programme fédéral de l’image de marque</a></li>
   <li><a href="https://www.canada.ca/fr/secretariat-conseil-tresor/services/communications-gouvernementales/specifications-contenu-architecture-information-canada/elements-obligatoires.html">Éléments obligatoires du système de conception</a></li>
 </ul>
 


### PR DESCRIPTION
Corrected the other two references that were missed in PR #179. The English has already all been fixed.  

"Small correction in the French name of the Federal Identity Program. It is now known in French as the Programme fédéral de l’image de marque instead of Programme de coordination de l’image de marque."