### PR TITLE
fixing typos: bibiothèque --> bibliothèque

### DIFF
--- a/modeles-recommandes/generique.html
+++ b/modeles-recommandes/generique.html
@@ -167,13 +167,13 @@
     <section>
       <h2 id="eviter">Quoi éviter</h2>
       <p>Avant de tenter de créer votre propre mise en page, vérifiez s'il existe un modèle obligatoire ou recommandé dans la bibliothèque pour le contenu que vous voulez publier.</p>
-      <a href="https://www.canada.ca/fr/gouvernement/a-propos/systeme-conception/bibliotheque-modeles.html">Bibiothèque de modèles et de configurations de conception</a> </section>
+      <a href="https://www.canada.ca/fr/gouvernement/a-propos/systeme-conception/bibliotheque-modeles.html">Bibliothèque de modèles et de configurations de conception</a> </section>
     <section>
       <h2 id="comment">Comment mettre en œuvre</h2>
       <p>Combinez les composantes et les modèles de la bibliothèque pour créer une page qui aidera les utilisateurs à accomplir leurs tâches. Assurez-vous de rédiger le contenu en suivant les principes du Guide de rédaction du contenu du site Canada.ca. </p>
       <ul>
         <li><a href="{{ site.url }}/architecture/elements-obligatoires.html">Éléments obligatoires du système de conception</a></li>
-        <li><a href="https://www.canada.ca/fr/gouvernement/a-propos/systeme-conception/bibliotheque-modeles.html">Bibiothèque de modèles et de configurations de conception</a></li>
+        <li><a href="https://www.canada.ca/fr/gouvernement/a-propos/systeme-conception/bibliotheque-modeles.html">Bibliothèque de modèles et de configurations de conception</a></li>
         <li><a href="https://www.canada.ca/fr/secretariat-conseil-tresor/services/communications-gouvernementales/guide-redaction-contenu-canada.html">Guide de rédaction</a></li>
       </ul>
       <p>Voici quelques exemples de mises en page avec lesquelles vous pouvez commencer :</p>


### PR DESCRIPTION
Just fixing a couple minor misspellings in 2 link labels on this page.

No equivalent EN PR needed.