### PR TITLE
Update navigation-metro.html

### DIFF
--- a/configurations-conception-communes/navigation-metro.html
+++ b/configurations-conception-communes/navigation-metro.html
@@ -144,7 +144,7 @@
 		</section>
 		<section>
 			<h2 id="quand">Quand utiliser cette configuration</h2>
-			<p>Utilisez cette configurtion pour regrouper des pages de tâches connexes et assurer la navigation entre ces pages. </p>
+			<p>Utilisez cette configuration pour regrouper des pages de tâches connexes et assurer la navigation entre ces pages. </p>
 			<p>Gardez le nombre de pages liées ensemble à un nombre raisonnable (idéalement 6 ou moins, maximum 8).</p>
 		</section>
 		<section>


### PR DESCRIPTION
French typo correction.
line 147, configuration had a missing ''a''. 
Only on the French version.