### PR TITLE
Update links in configuration files for GCWeb theme implementation

### DIFF
--- a/configurations-conception-communes/bloc-introduction.md
+++ b/configurations-conception-communes/bloc-introduction.md
@@ -147,7 +147,7 @@ title: Bloc d’introduction
     <h3>Référence pour la mise en œuvre du thème GCWeb (BOEW)</h3>
     <p>La référence à l’implémentation comprend la façon de configurer les éléments du système de conception.</p>
     <ul>
-        <li><a href="https://wet-boew.github.io/GCWeb/design-patterns/gc-intro/gc-intro-image-fr.html">Bloc d’introduction de GCWeb (BOEW)</a></li>
+        <li><a href="https://wet-boew.github.io/GCWeb/design-patterns/gc-intro/gc-intro-doc-fr.html">Bloc d’introduction de GCWeb (BOEW)</a></li>
         <li><a href="https://wet-boew.github.io/GCWeb/docs/implementing-fr.html">Guide de mise en œuvre rapide – thème GCWeb</a></li>
     </ul>
     <h3>Mises en œuvre</h3>

--- a/configurations-conception-communes/services-renseignements.md
+++ b/configurations-conception-communes/services-renseignements.md
@@ -123,7 +123,7 @@ title: Services et renseignements
   <p>Trouvez des exemples pratiques et de code pour mettre en œuvre la configuration de conception services et renseignements.</p>
   <h3>Référence pour la mise en œuvre des thèmes de GCWeb (BOEW)</h3>
   <ul>
-    <li><a href="https://wet-boew.github.io/GCWeb/components/gc-servinfo/gc-srvinfo.html">Services et renseignements&nbsp;-&nbsp;Configuration de conception courante (en anglais seulement)</a></li>
+    <li><a href="https://wet-boew.github.io/GCWeb/components/gc-srvinfo/gc-srvinfo-doc-fr.html">Services et renseignements&nbsp;-&nbsp;Configuration de conception courante</a></li>
   </ul>
   <h3>Mises en œuvre</h3>
   <p>Déterminez ce qui convient le mieux au type de page que vous créez.</p>


### PR DESCRIPTION
This pull request updates the links in the configuration files for the GCWeb theme implementation. The links have been corrected to point to the appropriate documentation pages for the GCWeb theme implementation.

## Alternate language PR
EN: https://github.com/canada-ca/design-system/pull/463